### PR TITLE
Problem memory range and ReadAsync

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.IO.Stream.ReadAsync(System.Memory{System.Byte},System.Threading.CancellationToken).cs
+++ b/Meziantou.Polyfill.Editor/M;System.IO.Stream.ReadAsync(System.Memory{System.Byte},System.Threading.CancellationToken).cs
@@ -15,7 +15,7 @@ static partial class PolyfillExtensions
             segment = new(buffer.ToArray());
         }
 
-        var read = await target.ReadAsync(segment.Array!, 0, buffer.Length);
+        var read = await target.ReadAsync(segment.Array!, segment.Offset, segment.Count);
         return read;
     }
 }

--- a/Meziantou.Polyfill.Tests/UnitTest1.cs
+++ b/Meziantou.Polyfill.Tests/UnitTest1.cs
@@ -250,6 +250,17 @@ public class UnitTest1
         Assert.Equal(2, result);
         Assert.Equal("te", new string(buffer));
     }
+
+    [Fact]
+    public async Task StreamReader_ReadAsync2()
+    {
+        using var sr = new MemoryStream([3, 4, 5]);
+        var buffer = new byte[3];
+        buffer[0] = 1;
+        var result = await sr.ReadAsync(buffer.AsMemory()[1..], CancellationToken.None);
+        Assert.Equal(2, result);
+        Assert.Equal([1,3,4], buffer);
+    }
 #endif
 
     [Fact]


### PR DESCRIPTION
Hi,

I got a problem with MemoryRange when there is an offset in ReadAsync.

I use the same code that there is in M;System.IO.TextReader.ReadAsync(System.Memory{System.Char},System.Threading.CancellationToken).cs

I create an unit test that raise the problem.