### PR TITLE
Update preprocessor checks for CollectionsMarshal usage

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.AggregateBy``3(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},``2,System.Func{``2,``0,``2},System.Collections.Generic.IEqualityComparer{``1}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.AggregateBy``3(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},``2,System.Func{``2,``0,``2},System.Collections.Generic.IEqualityComparer{``1}).cs
@@ -52,7 +52,7 @@ file class Helpers
 				TSource value = enumerator.Current;
 				TKey key = keySelector(value);
 								
-#if NET
+#if NET6_0_OR_GREATER
 				ref TAccumulate? acc = ref System.Runtime.InteropServices.CollectionsMarshal.GetValueRefOrAddDefault(dict, key, out bool exists);
 				acc = func(exists ? acc! : seed, value);
 #else

--- a/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.CountBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IEqualityComparer{``1}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.CountBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IEqualityComparer{``1}).cs
@@ -45,7 +45,7 @@ file class Helpers
             TSource value = enumerator.Current;
             TKey key = keySelector(value);
 
-#if NET
+#if NET6_0_OR_GREATER
             ref int currentCount = ref System.Runtime.InteropServices.CollectionsMarshal.GetValueRefOrAddDefault(countsBy, key, out _);
             checked
             {

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.72</Version>
+    <Version>1.0.73</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 


### PR DESCRIPTION
[`CollectionsMarshal.GetValueRefOrAddDefault` Method](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.collectionsmarshal.getvaluereforadddefault) is only available for **.NET 6.0** or greater.

Changed `#if NET` to `#if NET6_0_OR_GREATER` in relevant files to ensure `CollectionsMarshal.GetValueRefOrAddDefault` is only used when targeting **.NET 6.0** or greater, improving compatibility with earlier **.NET** versions.