### PR TITLE
Update AggregateBy for NET6_0_OR_GREATER; bump version

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.AggregateBy``3(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Func{``1,``2},System.Func{``2,``0,``2},System.Collections.Generic.IEqualityComparer{``1}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.AggregateBy``3(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Func{``1,``2},System.Func{``2,``0,``2},System.Collections.Generic.IEqualityComparer{``1}).cs
@@ -56,7 +56,7 @@ file class Helpers
 				TSource value = enumerator.Current;
 				TKey key = keySelector(value);
 								
-#if NET
+#if NET6_0_OR_GREATER
 				ref TAccumulate? acc = ref System.Runtime.InteropServices.CollectionsMarshal.GetValueRefOrAddDefault(dict, key, out bool exists);
 				acc = func(exists ? acc! : seedSelector(key), value);
 #else

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.74</Version>
+    <Version>1.0.75</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 


### PR DESCRIPTION
Use CollectionsMarshal.GetValueRefOrAddDefault only when targeting .NET 6.0 or greater by checking NET6_0_OR_GREATER instead of NET. Also, increment project version to 1.0.75.

Missed this one.

@meziantou, how do you search and edit these files?