### PR TITLE
Enhance WriteAsync method to handle ReadOnlyMemory<byte> more efficiently using MemoryMarshal

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.IO.Stream.DisposeAsync().cs
+++ b/Meziantou.Polyfill.Editor/M;System.IO.Stream.DisposeAsync().cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+
+static partial class PolyfillExtensions
+{
+    public static async ValueTask DisposeAsync(this Stream target)
+    {
+        if (target is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+        }
+        else
+        {
+            target.Dispose();
+        }
+    }
+}

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.75</Version>
+    <Version>1.0.76</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 


### PR DESCRIPTION
I also use these:

```csharp
public static async ValueTask<int> ReadAsync(this Stream stream, Memory<byte> buffer, CancellationToken cancellationToken = default)
{
    if (!MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment))
    {
        throw new NotSupportedException("The provided Memory<byte> is not backed by an array.");
    }

    return await stream.ReadAsync(segment.Array!, segment.Offset, segment.Count, cancellationToken).ConfigureAwait(false);
}

public static async ValueTask DisposeAsync(this Stream stream)
{
    if (stream is IAsyncDisposable asyncDisposable)
    {
        await asyncDisposable.DisposeAsync().ConfigureAwait(false);
    }
    else
    {
        stream.Dispose();
    }
}
```