### PR TITLE
Add polyfill for Task.WaitAsync and Task<TResult>.WaitAsync

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.Threading.Tasks.Task.WaitAsync(System.TimeSpan).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Threading.Tasks.Task.WaitAsync(System.TimeSpan).cs
@@ -1,0 +1,43 @@
+﻿using System.Threading.Tasks;
+using System.Threading;
+using System;
+
+static partial class PolyfillExtensions
+{
+    /// <summary>
+    /// Gets a <see cref="Task"/> that will complete when the <paramref name="task"/> completes or when the specified <paramref name="cancellationToken"/> has cancellation requested.
+    /// </summary>
+    /// <param name="task">The task to wait on for completion.</param>
+    /// <param name="timeout">The timeout after which the <see cref="Task"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
+    /// <returns>The <see cref="Task"/> representing the asynchronous wait.</returns>
+    public static Task WaitAsync(this Task task, TimeSpan timeout)
+    {
+        if (task.IsCompleted || timeout == Timeout.InfiniteTimeSpan)
+        {
+            return task;
+        }
+
+        if (timeout == TimeSpan.Zero)
+        {
+            return Task.FromException(new TimeoutException());
+        }
+
+        return WaitTask.WaitTaskAsync(task, timeout);
+    }
+}
+
+file static class WaitTask
+{
+    public static async Task WaitTaskAsync(Task task, TimeSpan timeout)
+    {
+        var delayTask = Task.Delay(timeout);
+        var t = await Task.WhenAny(task, delayTask).ConfigureAwait(false);
+
+        if (t == delayTask)
+        {
+            throw new TimeoutException();
+        }
+
+        task.GetAwaiter().GetResult();
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Threading.Tasks.Task.WaitAsync(System.TimeSpan,System.Threading.CancellationToken).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Threading.Tasks.Task.WaitAsync(System.TimeSpan,System.Threading.CancellationToken).cs
@@ -1,0 +1,50 @@
+﻿using System.Threading.Tasks;
+using System.Threading;
+using System;
+
+static partial class PolyfillExtensions
+{
+    /// <summary>
+    /// Gets a <see cref="Task"/> that will complete when the <paramref name="task"/> completes or when the specified <paramref name="cancellationToken"/> has cancellation requested.
+    /// </summary>
+    /// <param name="task">The task to wait on for completion.</param>
+    /// <param name="timeout">The timeout after which the <see cref="Task"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for a cancellation request.</param>
+    /// <returns>The <see cref="Task"/> representing the asynchronous wait.</returns>
+    public static Task WaitAsync(this Task task, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        if (task.IsCompleted || timeout == Timeout.InfiniteTimeSpan || (!cancellationToken.CanBeCanceled))
+        {
+            return task;
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        if (timeout == TimeSpan.Zero)
+        {
+            return Task.FromException(new TimeoutException());
+        }
+
+        return WaitTask.WaitTaskAsync(task, timeout, cancellationToken);
+    }
+}
+
+file static class WaitTask
+{
+    public static async Task WaitTaskAsync(Task task, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        var delayTask = Task.Delay(timeout, cancellationToken);
+        var t = await Task.WhenAny(task, delayTask).ConfigureAwait(false);
+
+        if (t == delayTask)
+        {
+            t.GetAwaiter().GetResult(); // Propagate cancellation
+            throw new TimeoutException();
+        }
+
+        task.GetAwaiter().GetResult();
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Threading.Tasks.Task`1.WaitAsync(System.Threading.CancellationToken).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Threading.Tasks.Task`1.WaitAsync(System.Threading.CancellationToken).cs
@@ -1,0 +1,40 @@
+﻿using System.Threading.Tasks;
+using System.Threading;
+
+static partial class PolyfillExtensions
+{
+    /// <summary>
+    /// Gets a <see cref="Task{TResult}"/> that will complete when the <paramref name="task"/> completes or when the specified <paramref name="cancellationToken"/> has cancellation requested.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the task result.</typeparam>
+    /// <param name="task">The task to wait on for completion.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for a cancellation request.</param>
+    /// <returns>The <see cref="Task{TResult}"/> representing the asynchronous wait.</returns>
+    public static Task<TResult> WaitAsync<TResult>(this Task<TResult> task, CancellationToken cancellationToken)
+    {
+        if (task.IsCompleted || (!cancellationToken.CanBeCanceled))
+        {
+            return task;
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<TResult>(cancellationToken);
+        }
+
+        return WaitTask.WaitTaskAsync(task, cancellationToken);
+    }
+}
+
+file static class WaitTask
+{
+    public static async Task<TResult> WaitTaskAsync<TResult>(Task<TResult> task, CancellationToken cancellationToken)
+    {
+        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using (cancellationToken.Register(static state => ((TaskCompletionSource<TResult>)state!).SetCanceled(), tcs, false))
+        {
+            var t = await Task.WhenAny(task, tcs.Task).ConfigureAwait(false);
+            return t.GetAwaiter().GetResult();
+        }
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Threading.Tasks.Task`1.WaitAsync(System.TimeSpan).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Threading.Tasks.Task`1.WaitAsync(System.TimeSpan).cs
@@ -1,0 +1,44 @@
+﻿using System.Threading.Tasks;
+using System.Threading;
+using System;
+
+static partial class PolyfillExtensions
+{
+    /// <summary>
+    /// Gets a <see cref="Task<TResult>{TResult}"/> that will complete when the <paramref name="task"/> completes or when the specified <paramref name="cancellationToken"/> has cancellation requested.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the task result.</typeparam>
+    /// <param name="task">The task to wait on for completion.</param>
+    /// <param name="timeout">The timeout after which the <see cref="Task<TResult>{TResult}"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
+    /// <returns>The <see cref="Task<TResult>{TResult}"/> representing the asynchronous wait.</returns>
+    public static Task<TResult> WaitAsync<TResult>(this Task<TResult> task, TimeSpan timeout)
+    {
+        if (task.IsCompleted || timeout == Timeout.InfiniteTimeSpan)
+        {
+            return task;
+        }
+
+        if (timeout == TimeSpan.Zero)
+        {
+            return Task.FromException<TResult>(new TimeoutException());
+        }
+
+        return WaitTask.WaitTaskAsync(task, timeout);
+    }
+}
+
+file static class WaitTask
+{
+    public static async Task<TResult> WaitTaskAsync<TResult>(Task<TResult> task, TimeSpan timeout)
+    {
+        var delayTask = Task<TResult>.Delay(timeout);
+        var t = await Task<TResult>.WhenAny(task, delayTask).ConfigureAwait(false);
+
+        if (t == delayTask)
+        {
+            throw new TimeoutException();
+        }
+
+        return task.GetAwaiter().GetResult();
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Threading.Tasks.Task`1.WaitAsync(System.TimeSpan,System.Threading.CancellationToken).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Threading.Tasks.Task`1.WaitAsync(System.TimeSpan,System.Threading.CancellationToken).cs
@@ -1,0 +1,51 @@
+﻿using System.Threading.Tasks;
+using System.Threading;
+using System;
+
+static partial class PolyfillExtensions
+{
+    /// <summary>
+    /// Gets a <see cref="Task<TResult>{TResult}"/> that will complete when the <paramref name="task"/> completes or when the specified <paramref name="cancellationToken"/> has cancellation requested.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the task result.</typeparam>
+    /// <param name="task">The task to wait on for completion.</param>
+    /// <param name="timeout">The timeout after which the <see cref="Task<TResult>{TResult}"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for a cancellation request.</param>
+    /// <returns>The <see cref="Task<TResult>{TResult}"/> representing the asynchronous wait.</returns>
+    public static Task<TResult> WaitAsync<TResult>(this Task<TResult> task, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        if (task.IsCompleted || timeout == Timeout.InfiniteTimeSpan || (!cancellationToken.CanBeCanceled))
+        {
+            return task;
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<TResult>(cancellationToken);
+        }
+
+        if (timeout == TimeSpan.Zero)
+        {
+            return Task.FromException<TResult>(new TimeoutException());
+        }
+
+        return WaitTask.WaitTaskAsync(task, timeout, cancellationToken);
+    }
+}
+
+file static class WaitTask
+{
+    public static async Task<TResult> WaitTaskAsync<TResult>(Task<TResult> task, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        var delayTask = Task<TResult>.Delay(timeout, cancellationToken);
+        var t = await Task<TResult>.WhenAny(task, delayTask).ConfigureAwait(false);
+
+        if (t == delayTask)
+        {
+            t.GetAwaiter().GetResult(); // Propagate cancellation
+            throw new TimeoutException();
+        }
+
+        return task.GetAwaiter().GetResult();
+    }
+}

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.77</Version>
+    <Version>1.0.78</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 


### PR DESCRIPTION
Introduce extension methods for Task.WaitAsync and Task<TResult>.WaitAsync with overloads for CancellationToken, TimeSpan, and TimeSpan plus CancellationToken. These methods mimic the .NET 6+ API, enabling tasks to be awaited with timeout and/or cancellation support. Implementation uses helper WaitTask classes to handle waiting logic, ensuring correct propagation of exceptions, cancellation, and timeouts.

@meziantou, I could add polyfills for the methods receiving `TimeProvider`, but that might require the user to add a reference to [`Microsoft.Bcl.TimeProvider`](https://www.nuget.org/packages/Microsoft.Bcl.TimeProvider).