### PR TITLE
Add span-based numeric Parse/TryParse polyfills

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.Byte.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Byte.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Byte
+{
+    extension(byte)
+    {
+        public static byte Parse(ReadOnlySpan<byte> utf8Text, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => byte.Parse(Encoding.UTF8.GetString(utf8Text), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Byte.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Byte.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Byte
+{
+    extension(byte)
+    {
+        public static byte Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) => byte.Parse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Byte.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Byte.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Byte
+{
+    extension(byte)
+    {
+        public static byte Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => byte.Parse(s.ToString(), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Byte.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Byte.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Byte
+{
+    extension(byte)
+    {
+        public static byte Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => byte.Parse(s.ToString(), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Byte.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.Byte@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Byte.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.Byte@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Byte
+{
+    extension(byte)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, NumberStyles style, IFormatProvider? provider, out byte result) => byte.TryParse(Encoding.UTF8.GetString(utf8Text), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Byte.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.Byte@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Byte.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.Byte@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Byte
+{
+    extension(byte)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out byte result) => byte.TryParse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Integer, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Byte.TryParse(System.ReadOnlySpan{System.Char},System.Byte@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Byte.TryParse(System.ReadOnlySpan{System.Char},System.Byte@).cs
@@ -1,0 +1,9 @@
+using System;
+
+static partial class PolyfillExtensions_Byte
+{
+    extension(byte)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, out byte result) => byte.TryParse(s.ToString(), out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Byte.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.Byte@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Byte.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.Byte@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Byte
+{
+    extension(byte)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out byte result) => byte.TryParse(s.ToString(), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Byte.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.Byte@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Byte.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.Byte@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Byte
+{
+    extension(byte)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out byte result) => byte.TryParse(s.ToString(), NumberStyles.Integer, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Decimal.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Decimal.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Decimal
+{
+    extension(decimal)
+    {
+        public static decimal Parse(ReadOnlySpan<byte> utf8Text, NumberStyles style = NumberStyles.Number, IFormatProvider? provider = null) => decimal.Parse(Encoding.UTF8.GetString(utf8Text), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Decimal.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Decimal.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Decimal
+{
+    extension(decimal)
+    {
+        public static decimal Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) => decimal.Parse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Number, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Decimal.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Decimal.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Decimal
+{
+    extension(decimal)
+    {
+        public static decimal Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Number, IFormatProvider? provider = null) => decimal.Parse(s.ToString(), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Decimal.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Decimal.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Decimal
+{
+    extension(decimal)
+    {
+        public static decimal Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => decimal.Parse(s.ToString(), NumberStyles.Number, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Decimal.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.Decimal@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Decimal.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.Decimal@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Decimal
+{
+    extension(decimal)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, NumberStyles style, IFormatProvider? provider, out decimal result) => decimal.TryParse(Encoding.UTF8.GetString(utf8Text), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Decimal.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.Decimal@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Decimal.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.Decimal@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Decimal
+{
+    extension(decimal)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out decimal result) => decimal.TryParse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Number, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Decimal.TryParse(System.ReadOnlySpan{System.Char},System.Decimal@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Decimal.TryParse(System.ReadOnlySpan{System.Char},System.Decimal@).cs
@@ -1,0 +1,9 @@
+using System;
+
+static partial class PolyfillExtensions_Decimal
+{
+    extension(decimal)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, out decimal result) => decimal.TryParse(s.ToString(), out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Decimal.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.Decimal@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Decimal.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.Decimal@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Decimal
+{
+    extension(decimal)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out decimal result) => decimal.TryParse(s.ToString(), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Decimal.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.Decimal@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Decimal.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.Decimal@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Decimal
+{
+    extension(decimal)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out decimal result) => decimal.TryParse(s.ToString(), NumberStyles.Number, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Double.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Double.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Double
+{
+    extension(double)
+    {
+        public static double Parse(ReadOnlySpan<byte> utf8Text, NumberStyles style = NumberStyles.Float | NumberStyles.AllowThousands, IFormatProvider? provider = null) => double.Parse(Encoding.UTF8.GetString(utf8Text), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Double.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Double.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Double
+{
+    extension(double)
+    {
+        public static double Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) => double.Parse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Float | NumberStyles.AllowThousands, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Double.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Double.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Double
+{
+    extension(double)
+    {
+        public static double Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Float | NumberStyles.AllowThousands, IFormatProvider? provider = null) => double.Parse(s.ToString(), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Double.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Double.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Double
+{
+    extension(double)
+    {
+        public static double Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => double.Parse(s.ToString(), NumberStyles.Float | NumberStyles.AllowThousands, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Double.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.Double@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Double.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.Double@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Double
+{
+    extension(double)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, NumberStyles style, IFormatProvider? provider, out double result) => double.TryParse(Encoding.UTF8.GetString(utf8Text), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Double.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.Double@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Double.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.Double@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Double
+{
+    extension(double)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out double result) => double.TryParse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Double.TryParse(System.ReadOnlySpan{System.Char},System.Double@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Double.TryParse(System.ReadOnlySpan{System.Char},System.Double@).cs
@@ -1,0 +1,9 @@
+using System;
+
+static partial class PolyfillExtensions_Double
+{
+    extension(double)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, out double result) => double.TryParse(s.ToString(), out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Double.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.Double@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Double.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.Double@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Double
+{
+    extension(double)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out double result) => double.TryParse(s.ToString(), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Double.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.Double@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Double.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.Double@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Double
+{
+    extension(double)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out double result) => double.TryParse(s.ToString(), NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int16.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int16.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Int16
+{
+    extension(short)
+    {
+        public static short Parse(ReadOnlySpan<byte> utf8Text, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => short.Parse(Encoding.UTF8.GetString(utf8Text), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int16.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int16.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Int16
+{
+    extension(short)
+    {
+        public static short Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) => short.Parse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int16.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int16.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Int16
+{
+    extension(short)
+    {
+        public static short Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => short.Parse(s.ToString(), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int16.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int16.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Int16
+{
+    extension(short)
+    {
+        public static short Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => short.Parse(s.ToString(), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int16.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.Int16@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int16.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.Int16@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Int16
+{
+    extension(short)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, NumberStyles style, IFormatProvider? provider, out short result) => short.TryParse(Encoding.UTF8.GetString(utf8Text), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int16.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.Int16@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int16.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.Int16@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Int16
+{
+    extension(short)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out short result) => short.TryParse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Integer, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int16.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.Int16@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int16.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.Int16@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Int16
+{
+    extension(short)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out short result) => short.TryParse(s.ToString(), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int16.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.Int16@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int16.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.Int16@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Int16
+{
+    extension(short)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out short result) => short.TryParse(s.ToString(), NumberStyles.Integer, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int16.TryParse(System.ReadOnlySpan{System.Char},System.Int16@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int16.TryParse(System.ReadOnlySpan{System.Char},System.Int16@).cs
@@ -1,0 +1,9 @@
+using System;
+
+static partial class PolyfillExtensions_Int16
+{
+    extension(short)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, out short result) => short.TryParse(s.ToString(), out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int32.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int32.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Int32
+{
+    extension(int)
+    {
+        public static int Parse(ReadOnlySpan<byte> utf8Text, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => int.Parse(Encoding.UTF8.GetString(utf8Text), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int32.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int32.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Int32
+{
+    extension(int)
+    {
+        public static int Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) => int.Parse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int32.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int32.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Int32
+{
+    extension(int)
+    {
+        public static int Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => int.Parse(s.ToString(), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int32.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int32.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Int32
+{
+    extension(int)
+    {
+        public static int Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => int.Parse(s.ToString(), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int32.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.Int32@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int32.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.Int32@).cs
@@ -2,7 +2,7 @@ using System;
 using System.Globalization;
 using System.Text;
 
-static partial class PolyfillExtensions
+static partial class PolyfillExtensions_Int32
 {
     extension(int)
     {

--- a/Meziantou.Polyfill.Editor/M;System.Int32.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.Int32@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int32.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.Int32@).cs
@@ -2,7 +2,7 @@ using System;
 using System.Globalization;
 using System.Text;
 
-static partial class PolyfillExtensions
+static partial class PolyfillExtensions_Int32
 {
     extension(int)
     {

--- a/Meziantou.Polyfill.Editor/M;System.Int32.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.Int32@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int32.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.Int32@).cs
@@ -1,7 +1,7 @@
 using System;
 using System.Globalization;
 
-static partial class PolyfillExtensions
+static partial class PolyfillExtensions_Int32
 {
     extension(int)
     {

--- a/Meziantou.Polyfill.Editor/M;System.Int32.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.Int32@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int32.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.Int32@).cs
@@ -1,7 +1,7 @@
 using System;
 using System.Globalization;
 
-static partial class PolyfillExtensions
+static partial class PolyfillExtensions_Int32
 {
     extension(int)
     {

--- a/Meziantou.Polyfill.Editor/M;System.Int32.TryParse(System.ReadOnlySpan{System.Char},System.Int32@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int32.TryParse(System.ReadOnlySpan{System.Char},System.Int32@).cs
@@ -1,0 +1,9 @@
+using System;
+
+static partial class PolyfillExtensions_Int32
+{
+    extension(int)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, out int result) => int.TryParse(s.ToString(), out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int64.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int64.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Int64
+{
+    extension(long)
+    {
+        public static long Parse(ReadOnlySpan<byte> utf8Text, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => long.Parse(Encoding.UTF8.GetString(utf8Text), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int64.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int64.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Int64
+{
+    extension(long)
+    {
+        public static long Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) => long.Parse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int64.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int64.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Int64
+{
+    extension(long)
+    {
+        public static long Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => long.Parse(s.ToString(), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int64.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int64.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Int64
+{
+    extension(long)
+    {
+        public static long Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => long.Parse(s.ToString(), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int64.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.Int64@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int64.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.Int64@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Int64
+{
+    extension(long)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, NumberStyles style, IFormatProvider? provider, out long result) => long.TryParse(Encoding.UTF8.GetString(utf8Text), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int64.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.Int64@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int64.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.Int64@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Int64
+{
+    extension(long)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out long result) => long.TryParse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Integer, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int64.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.Int64@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int64.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.Int64@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Int64
+{
+    extension(long)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out long result) => long.TryParse(s.ToString(), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int64.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.Int64@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int64.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.Int64@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Int64
+{
+    extension(long)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out long result) => long.TryParse(s.ToString(), NumberStyles.Integer, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Int64.TryParse(System.ReadOnlySpan{System.Char},System.Int64@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Int64.TryParse(System.ReadOnlySpan{System.Char},System.Int64@).cs
@@ -1,0 +1,9 @@
+using System;
+
+static partial class PolyfillExtensions_Int64
+{
+    extension(long)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, out long result) => long.TryParse(s.ToString(), out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.SByte.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.SByte.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_SByte
+{
+    extension(sbyte)
+    {
+        public static sbyte Parse(ReadOnlySpan<byte> utf8Text, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => sbyte.Parse(Encoding.UTF8.GetString(utf8Text), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.SByte.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.SByte.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_SByte
+{
+    extension(sbyte)
+    {
+        public static sbyte Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) => sbyte.Parse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.SByte.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.SByte.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_SByte
+{
+    extension(sbyte)
+    {
+        public static sbyte Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => sbyte.Parse(s.ToString(), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.SByte.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.SByte.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_SByte
+{
+    extension(sbyte)
+    {
+        public static sbyte Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => sbyte.Parse(s.ToString(), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.SByte.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.SByte@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.SByte.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.SByte@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_SByte
+{
+    extension(sbyte)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, NumberStyles style, IFormatProvider? provider, out sbyte result) => sbyte.TryParse(Encoding.UTF8.GetString(utf8Text), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.SByte.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.SByte@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.SByte.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.SByte@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_SByte
+{
+    extension(sbyte)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out sbyte result) => sbyte.TryParse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Integer, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.SByte.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.SByte@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.SByte.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.SByte@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_SByte
+{
+    extension(sbyte)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out sbyte result) => sbyte.TryParse(s.ToString(), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.SByte.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.SByte@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.SByte.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.SByte@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_SByte
+{
+    extension(sbyte)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out sbyte result) => sbyte.TryParse(s.ToString(), NumberStyles.Integer, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.SByte.TryParse(System.ReadOnlySpan{System.Char},System.SByte@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.SByte.TryParse(System.ReadOnlySpan{System.Char},System.SByte@).cs
@@ -1,0 +1,9 @@
+using System;
+
+static partial class PolyfillExtensions_SByte
+{
+    extension(sbyte)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, out sbyte result) => sbyte.TryParse(s.ToString(), out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Single.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Single.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Single
+{
+    extension(float)
+    {
+        public static float Parse(ReadOnlySpan<byte> utf8Text, NumberStyles style = NumberStyles.Float | NumberStyles.AllowThousands, IFormatProvider? provider = null) => float.Parse(Encoding.UTF8.GetString(utf8Text), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Single.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Single.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Single
+{
+    extension(float)
+    {
+        public static float Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) => float.Parse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Float | NumberStyles.AllowThousands, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Single.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Single.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Single
+{
+    extension(float)
+    {
+        public static float Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Float | NumberStyles.AllowThousands, IFormatProvider? provider = null) => float.Parse(s.ToString(), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Single.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Single.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Single
+{
+    extension(float)
+    {
+        public static float Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => float.Parse(s.ToString(), NumberStyles.Float | NumberStyles.AllowThousands, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Single.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.Single@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Single.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.Single@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Single
+{
+    extension(float)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, NumberStyles style, IFormatProvider? provider, out float result) => float.TryParse(Encoding.UTF8.GetString(utf8Text), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Single.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.Single@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Single.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.Single@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_Single
+{
+    extension(float)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out float result) => float.TryParse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Single.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.Single@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Single.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.Single@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Single
+{
+    extension(float)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out float result) => float.TryParse(s.ToString(), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Single.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.Single@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Single.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.Single@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_Single
+{
+    extension(float)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out float result) => float.TryParse(s.ToString(), NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Single.TryParse(System.ReadOnlySpan{System.Char},System.Single@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Single.TryParse(System.ReadOnlySpan{System.Char},System.Single@).cs
@@ -1,0 +1,9 @@
+using System;
+
+static partial class PolyfillExtensions_Single
+{
+    extension(float)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, out float result) => float.TryParse(s.ToString(), out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt16.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt16.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_UInt16
+{
+    extension(ushort)
+    {
+        public static ushort Parse(ReadOnlySpan<byte> utf8Text, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => ushort.Parse(Encoding.UTF8.GetString(utf8Text), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt16.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt16.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_UInt16
+{
+    extension(ushort)
+    {
+        public static ushort Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) => ushort.Parse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt16.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt16.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_UInt16
+{
+    extension(ushort)
+    {
+        public static ushort Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => ushort.Parse(s.ToString(), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt16.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt16.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_UInt16
+{
+    extension(ushort)
+    {
+        public static ushort Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => ushort.Parse(s.ToString(), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt16.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.UInt16@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt16.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.UInt16@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_UInt16
+{
+    extension(ushort)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, NumberStyles style, IFormatProvider? provider, out ushort result) => ushort.TryParse(Encoding.UTF8.GetString(utf8Text), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt16.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.UInt16@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt16.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.UInt16@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_UInt16
+{
+    extension(ushort)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out ushort result) => ushort.TryParse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Integer, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt16.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.UInt16@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt16.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.UInt16@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_UInt16
+{
+    extension(ushort)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out ushort result) => ushort.TryParse(s.ToString(), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt16.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.UInt16@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt16.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.UInt16@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_UInt16
+{
+    extension(ushort)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out ushort result) => ushort.TryParse(s.ToString(), NumberStyles.Integer, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt16.TryParse(System.ReadOnlySpan{System.Char},System.UInt16@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt16.TryParse(System.ReadOnlySpan{System.Char},System.UInt16@).cs
@@ -1,0 +1,9 @@
+using System;
+
+static partial class PolyfillExtensions_UInt16
+{
+    extension(ushort)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, out ushort result) => ushort.TryParse(s.ToString(), out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt32.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt32.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_UInt32
+{
+    extension(uint)
+    {
+        public static uint Parse(ReadOnlySpan<byte> utf8Text, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => uint.Parse(Encoding.UTF8.GetString(utf8Text), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt32.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt32.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_UInt32
+{
+    extension(uint)
+    {
+        public static uint Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) => uint.Parse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt32.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt32.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_UInt32
+{
+    extension(uint)
+    {
+        public static uint Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => uint.Parse(s.ToString(), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt32.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt32.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_UInt32
+{
+    extension(uint)
+    {
+        public static uint Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => uint.Parse(s.ToString(), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt32.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.UInt32@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt32.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.UInt32@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_UInt32
+{
+    extension(uint)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, NumberStyles style, IFormatProvider? provider, out uint result) => uint.TryParse(Encoding.UTF8.GetString(utf8Text), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt32.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.UInt32@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt32.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.UInt32@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_UInt32
+{
+    extension(uint)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out uint result) => uint.TryParse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Integer, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt32.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.UInt32@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt32.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.UInt32@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_UInt32
+{
+    extension(uint)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out uint result) => uint.TryParse(s.ToString(), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt32.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.UInt32@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt32.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.UInt32@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_UInt32
+{
+    extension(uint)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out uint result) => uint.TryParse(s.ToString(), NumberStyles.Integer, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt32.TryParse(System.ReadOnlySpan{System.Char},System.UInt32@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt32.TryParse(System.ReadOnlySpan{System.Char},System.UInt32@).cs
@@ -1,0 +1,9 @@
+using System;
+
+static partial class PolyfillExtensions_UInt32
+{
+    extension(uint)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, out uint result) => uint.TryParse(s.ToString(), out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt64.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt64.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_UInt64
+{
+    extension(ulong)
+    {
+        public static ulong Parse(ReadOnlySpan<byte> utf8Text, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => ulong.Parse(Encoding.UTF8.GetString(utf8Text), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt64.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt64.Parse(System.ReadOnlySpan{System.Byte},System.IFormatProvider).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_UInt64
+{
+    extension(ulong)
+    {
+        public static ulong Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) => ulong.Parse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt64.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt64.Parse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_UInt64
+{
+    extension(ulong)
+    {
+        public static ulong Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => ulong.Parse(s.ToString(), style, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt64.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt64.Parse(System.ReadOnlySpan{System.Char},System.IFormatProvider).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_UInt64
+{
+    extension(ulong)
+    {
+        public static ulong Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => ulong.Parse(s.ToString(), NumberStyles.Integer, provider);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt64.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.UInt64@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt64.TryParse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider,System.UInt64@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_UInt64
+{
+    extension(ulong)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, NumberStyles style, IFormatProvider? provider, out ulong result) => ulong.TryParse(Encoding.UTF8.GetString(utf8Text), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt64.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.UInt64@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt64.TryParse(System.ReadOnlySpan{System.Byte},System.IFormatProvider,System.UInt64@).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+static partial class PolyfillExtensions_UInt64
+{
+    extension(ulong)
+    {
+        public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out ulong result) => ulong.TryParse(Encoding.UTF8.GetString(utf8Text), NumberStyles.Integer, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt64.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.UInt64@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt64.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.UInt64@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_UInt64
+{
+    extension(ulong)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out ulong result) => ulong.TryParse(s.ToString(), style, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt64.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.UInt64@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt64.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.UInt64@).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Globalization;
+
+static partial class PolyfillExtensions_UInt64
+{
+    extension(ulong)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out ulong result) => ulong.TryParse(s.ToString(), NumberStyles.Integer, provider, out result);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.UInt64.TryParse(System.ReadOnlySpan{System.Char},System.UInt64@).cs
+++ b/Meziantou.Polyfill.Editor/M;System.UInt64.TryParse(System.ReadOnlySpan{System.Char},System.UInt64@).cs
@@ -1,0 +1,9 @@
+using System;
+
+static partial class PolyfillExtensions_UInt64
+{
+    extension(ulong)
+    {
+        public static bool TryParse(ReadOnlySpan<char> s, out ulong result) => ulong.TryParse(s.ToString(), out result);
+    }
+}

--- a/Meziantou.Polyfill.Tests/SystemTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemTests.cs
@@ -805,6 +805,430 @@ public class SystemTests
     }
 
     [Fact]
+    public void String_Create()
+    {
+        var actual = string.Create(CultureInfo.InvariantCulture, $"a{1}b");
+        Assert.Equal("a1b", actual);
+    }
+
+    [Fact]
+    public void Single_Parse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        // Basic parsing from UTF8
+        ReadOnlySpan<byte> utf8Data = "123.45"u8;
+        var result = float.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(123.45f, result, 2);
+
+        // Scientific notation
+        utf8Data = "1.23e+2"u8;
+        result = float.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(123f, result, 0);
+
+        // Negative numbers
+        utf8Data = "-456.78"u8;
+        result = float.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(-456.78f, result, 2);
+    }
+
+    [Fact]
+    public void Single_Parse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        // Basic parsing with style
+        ReadOnlySpan<byte> utf8Data = "123.45"u8;
+        var result = float.Parse(utf8Data, NumberStyles.Float, CultureInfo.InvariantCulture);
+        Assert.Equal(123.45f, result, 2);
+
+        // Allow leading whitespace
+        utf8Data = "  456.78"u8;
+        result = float.Parse(utf8Data, NumberStyles.Float, CultureInfo.InvariantCulture);
+        Assert.Equal(456.78f, result, 2);
+    }
+
+    [Fact]
+    public void Single_TryParse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        // Basic parsing from UTF8
+        ReadOnlySpan<byte> utf8Data = "123.45"u8;
+        Assert.True(float.TryParse(utf8Data, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(123.45f, result, 2);
+
+        // Invalid UTF8 input
+        utf8Data = "abc"u8;
+        Assert.False(float.TryParse(utf8Data, CultureInfo.InvariantCulture, out result));
+        Assert.Equal(0f, result);
+
+        // Empty span
+        Assert.False(float.TryParse(ReadOnlySpan<byte>.Empty, CultureInfo.InvariantCulture, out _));
+
+        // Null provider
+        utf8Data = "789.01"u8;
+        Assert.True(float.TryParse(utf8Data, null, out result));
+        Assert.Equal(789.01f, result, 2);
+    }
+
+    [Fact]
+    public void Single_TryParse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        // Parsing with style
+        ReadOnlySpan<byte> utf8Data = "123.45"u8;
+        Assert.True(float.TryParse(utf8Data, NumberStyles.Float, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(123.45f, result, 2);
+
+        // Invalid with specified style
+        utf8Data = "ABC"u8;
+        Assert.False(float.TryParse(utf8Data, NumberStyles.Float, CultureInfo.InvariantCulture, out result));
+        Assert.Equal(0f, result);
+
+        // Null provider
+        utf8Data = "42.5"u8;
+        Assert.True(float.TryParse(utf8Data, NumberStyles.Float, null, out result));
+        Assert.Equal(42.5f, result, 1);
+    }
+
+    [Fact]
+    public void Double_Parse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        // Basic parsing from UTF8
+        ReadOnlySpan<byte> utf8Data = "123.456"u8;
+        var result = double.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(123.456d, result, 3);
+
+        // Scientific notation
+        utf8Data = "1.23e+2"u8;
+        result = double.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(123d, result, 0);
+
+        // Negative numbers
+        utf8Data = "-456.789"u8;
+        result = double.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(-456.789d, result, 3);
+    }
+
+    [Fact]
+    public void Double_Parse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        // Basic parsing with style
+        ReadOnlySpan<byte> utf8Data = "123.456"u8;
+        var result = double.Parse(utf8Data, NumberStyles.Float, CultureInfo.InvariantCulture);
+        Assert.Equal(123.456d, result, 3);
+
+        // Allow leading whitespace
+        utf8Data = "  456.789"u8;
+        result = double.Parse(utf8Data, NumberStyles.Float, CultureInfo.InvariantCulture);
+        Assert.Equal(456.789d, result, 3);
+    }
+
+    [Fact]
+    public void Double_TryParse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        // Basic parsing from UTF8
+        ReadOnlySpan<byte> utf8Data = "123.456"u8;
+        Assert.True(double.TryParse(utf8Data, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(123.456d, result, 3);
+
+        // Invalid UTF8 input
+        utf8Data = "abc"u8;
+        Assert.False(double.TryParse(utf8Data, CultureInfo.InvariantCulture, out result));
+        Assert.Equal(0d, result);
+
+        // Empty span
+        Assert.False(double.TryParse(ReadOnlySpan<byte>.Empty, CultureInfo.InvariantCulture, out _));
+
+        // Null provider
+        utf8Data = "789.012"u8;
+        Assert.True(double.TryParse(utf8Data, null, out result));
+        Assert.Equal(789.012d, result, 3);
+    }
+
+    [Fact]
+    public void Double_TryParse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        // Parsing with style
+        ReadOnlySpan<byte> utf8Data = "123.456"u8;
+        Assert.True(double.TryParse(utf8Data, NumberStyles.Float, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(123.456d, result, 3);
+
+        // Invalid with specified style
+        utf8Data = "ABC"u8;
+        Assert.False(double.TryParse(utf8Data, NumberStyles.Float, CultureInfo.InvariantCulture, out result));
+        Assert.Equal(0d, result);
+
+        // Null provider
+        utf8Data = "42.5"u8;
+        Assert.True(double.TryParse(utf8Data, NumberStyles.Float, null, out result));
+        Assert.Equal(42.5d, result, 1);
+    }
+
+    [Fact]
+    public void Decimal_Parse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        // Basic parsing from UTF8
+        ReadOnlySpan<byte> utf8Data = "123.45"u8;
+        var result = decimal.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(123.45m, result);
+
+        // Large number
+        utf8Data = "999999999999.99"u8;
+        result = decimal.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(999999999999.99m, result);
+
+        // Negative numbers
+        utf8Data = "-456.78"u8;
+        result = decimal.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(-456.78m, result);
+    }
+
+    [Fact]
+    public void Decimal_Parse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        // Basic parsing with style
+        ReadOnlySpan<byte> utf8Data = "123.45"u8;
+        var result = decimal.Parse(utf8Data, NumberStyles.Number, CultureInfo.InvariantCulture);
+        Assert.Equal(123.45m, result);
+
+        // Allow leading whitespace
+        utf8Data = "  456.78"u8;
+        result = decimal.Parse(utf8Data, NumberStyles.Number, CultureInfo.InvariantCulture);
+        Assert.Equal(456.78m, result);
+    }
+
+    [Fact]
+    public void Decimal_TryParse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        // Basic parsing from UTF8
+        ReadOnlySpan<byte> utf8Data = "123.45"u8;
+        Assert.True(decimal.TryParse(utf8Data, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(123.45m, result);
+
+        // Invalid UTF8 input
+        utf8Data = "abc"u8;
+        Assert.False(decimal.TryParse(utf8Data, CultureInfo.InvariantCulture, out result));
+        Assert.Equal(0m, result);
+
+        // Empty span
+        Assert.False(decimal.TryParse(ReadOnlySpan<byte>.Empty, CultureInfo.InvariantCulture, out _));
+
+        // Null provider
+        utf8Data = "789.01"u8;
+        Assert.True(decimal.TryParse(utf8Data, null, out result));
+        Assert.Equal(789.01m, result);
+    }
+
+    [Fact]
+    public void Decimal_TryParse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        // Parsing with style
+        ReadOnlySpan<byte> utf8Data = "123.45"u8;
+        Assert.True(decimal.TryParse(utf8Data, NumberStyles.Number, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(123.45m, result);
+
+        // Invalid with specified style
+        utf8Data = "ABC"u8;
+        Assert.False(decimal.TryParse(utf8Data, NumberStyles.Number, CultureInfo.InvariantCulture, out result));
+        Assert.Equal(0m, result);
+
+        // Null provider
+        utf8Data = "42.5"u8;
+        Assert.True(decimal.TryParse(utf8Data, NumberStyles.Number, null, out result));
+        Assert.Equal(42.5m, result);
+    }
+
+    [Fact]
+    public void Byte_Parse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "255"u8;
+        var result = byte.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(255, result);
+
+        utf8Data = "0"u8;
+        result = byte.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void Byte_Parse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "FF"u8;
+        var result = byte.Parse(utf8Data, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        Assert.Equal(255, result);
+    }
+
+    [Fact]
+    public void Byte_TryParse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "123"u8;
+        Assert.True(byte.TryParse(utf8Data, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(123, result);
+
+        utf8Data = "256"u8;
+        Assert.False(byte.TryParse(utf8Data, CultureInfo.InvariantCulture, out _));
+    }
+
+    [Fact]
+    public void Byte_TryParse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "FF"u8;
+        Assert.True(byte.TryParse(utf8Data, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(255, result);
+    }
+
+    [Fact]
+    public void SByte_Parse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "127"u8;
+        var result = sbyte.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(127, result);
+
+        utf8Data = "-128"u8;
+        result = sbyte.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(-128, result);
+    }
+
+    [Fact]
+    public void SByte_Parse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "7F"u8;
+        var result = sbyte.Parse(utf8Data, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        Assert.Equal(127, result);
+    }
+
+    [Fact]
+    public void SByte_TryParse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "100"u8;
+        Assert.True(sbyte.TryParse(utf8Data, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(100, result);
+
+        utf8Data = "128"u8;
+        Assert.False(sbyte.TryParse(utf8Data, CultureInfo.InvariantCulture, out _));
+    }
+
+    [Fact]
+    public void SByte_TryParse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "7F"u8;
+        Assert.True(sbyte.TryParse(utf8Data, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(127, result);
+    }
+
+    [Fact]
+    public void Int16_Parse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "32767"u8;
+        var result = short.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(32767, result);
+
+        utf8Data = "-32768"u8;
+        result = short.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(-32768, result);
+    }
+
+    [Fact]
+    public void Int16_Parse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "7FFF"u8;
+        var result = short.Parse(utf8Data, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        Assert.Equal(32767, result);
+    }
+
+    [Fact]
+    public void Int16_TryParse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "1000"u8;
+        Assert.True(short.TryParse(utf8Data, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(1000, result);
+
+        utf8Data = "32768"u8;
+        Assert.False(short.TryParse(utf8Data, CultureInfo.InvariantCulture, out _));
+    }
+
+    [Fact]
+    public void Int16_TryParse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "7FFF"u8;
+        Assert.True(short.TryParse(utf8Data, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(32767, result);
+    }
+
+    [Fact]
+    public void UInt16_Parse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "65535"u8;
+        var result = ushort.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(65535, result);
+
+        utf8Data = "0"u8;
+        result = ushort.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void UInt16_Parse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "FFFF"u8;
+        var result = ushort.Parse(utf8Data, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        Assert.Equal(65535, result);
+    }
+
+    [Fact]
+    public void UInt16_TryParse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "50000"u8;
+        Assert.True(ushort.TryParse(utf8Data, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(50000, result);
+
+        utf8Data = "65536"u8;
+        Assert.False(ushort.TryParse(utf8Data, CultureInfo.InvariantCulture, out _));
+    }
+
+    [Fact]
+    public void UInt16_TryParse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "FFFF"u8;
+        Assert.True(ushort.TryParse(utf8Data, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(65535, result);
+    }
+
+    [Fact]
+    public void UInt32_Parse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "4294967295"u8;
+        var result = uint.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(4294967295u, result);
+
+        utf8Data = "0"u8;
+        result = uint.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(0u, result);
+    }
+
+    [Fact]
+    public void UInt32_Parse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "FFFFFFFF"u8;
+        var result = uint.Parse(utf8Data, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        Assert.Equal(4294967295u, result);
+    }
+
+    [Fact]
+    public void UInt32_TryParse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "1000000000"u8;
+        Assert.True(uint.TryParse(utf8Data, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(1000000000u, result);
+
+        utf8Data = "4294967296"u8;
+        Assert.False(uint.TryParse(utf8Data, CultureInfo.InvariantCulture, out _));
+    }
+
+    [Fact]
+    public void UInt32_TryParse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "FFFFFFFF"u8;
+        Assert.True(uint.TryParse(utf8Data, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(4294967295u, result);
+    }
+
+    [Fact]
     public void Int32_TryParse_ReadOnlySpan_Char()
     {
         // Basic parsing
@@ -899,10 +1323,81 @@ public class SystemTests
     }
 
     [Fact]
-    public void String_Create()
+    public void UInt64_Parse_ReadOnlySpan_Byte_IFormatProvider()
     {
-        var actual = string.Create(CultureInfo.InvariantCulture, $"a{1}b");
-        Assert.Equal("a1b", actual);
+        ReadOnlySpan<byte> utf8Data = "18446744073709551615"u8;
+        var result = ulong.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(18446744073709551615ul, result);
+
+        utf8Data = "0"u8;
+        result = ulong.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(0ul, result);
+    }
+
+    [Fact]
+    public void UInt64_Parse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "FFFFFFFFFFFFFFFF"u8;
+        var result = ulong.Parse(utf8Data, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        Assert.Equal(18446744073709551615ul, result);
+    }
+
+    [Fact]
+    public void UInt64_TryParse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "10000000000000000000"u8;
+        Assert.True(ulong.TryParse(utf8Data, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(10000000000000000000ul, result);
+
+        utf8Data = "18446744073709551616"u8;
+        Assert.False(ulong.TryParse(utf8Data, CultureInfo.InvariantCulture, out _));
+    }
+
+    [Fact]
+    public void UInt64_TryParse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "FFFFFFFFFFFFFFFF"u8;
+        Assert.True(ulong.TryParse(utf8Data, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(18446744073709551615ul, result);
+    }
+
+    [Fact]
+    public void Int64_Parse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "9223372036854775807"u8;
+        var result = long.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(9223372036854775807L, result);
+
+        utf8Data = "-9223372036854775808"u8;
+        result = long.Parse(utf8Data, CultureInfo.InvariantCulture);
+        Assert.Equal(-9223372036854775808L, result);
+    }
+
+    [Fact]
+    public void Int64_Parse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "7FFFFFFFFFFFFFFF"u8;
+        var result = long.Parse(utf8Data, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        Assert.Equal(9223372036854775807L, result);
+    }
+
+    [Fact]
+    public void Int64_TryParse_ReadOnlySpan_Byte_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "1000000000000000000"u8;
+        Assert.True(long.TryParse(utf8Data, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(1000000000000000000L, result);
+
+        utf8Data = "9223372036854775808"u8;
+        Assert.False(long.TryParse(utf8Data, CultureInfo.InvariantCulture, out _));
+    }
+
+    [Fact]
+    public void Int64_TryParse_ReadOnlySpan_Byte_NumberStyles_IFormatProvider()
+    {
+        ReadOnlySpan<byte> utf8Data = "7FFFFFFFFFFFFFFF"u8;
+        Assert.True(long.TryParse(utf8Data, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(9223372036854775807L, result);
     }
 
 }

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.82</Version>
+    <Version>1.0.83</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ By default, all needed polyfills are generated. You can configure which polyfill
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 - `System.ITupleInternal`
 
-### Methods (330)
+### Methods (425)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -122,6 +122,15 @@ By default, all needed polyfills are generated. You can configure which polyfill
 - `System.ArgumentOutOfRangeException.ThrowIfNotEqual<T>(T value, T other, [System.String? paramName = null])`
 - `System.BitConverter.ToInt16(System.ReadOnlySpan<System.Byte> value)`
 - `System.BitConverter.ToInt32(System.ReadOnlySpan<System.Byte> value)`
+- `System.Byte.Parse(System.ReadOnlySpan<System.Byte> utf8Text, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.Byte.Parse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider)`
+- `System.Byte.Parse(System.ReadOnlySpan<System.Char> s, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.Byte.Parse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider)`
+- `System.Byte.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Byte result)`
+- `System.Byte.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider, out System.Byte result)`
+- `System.Byte.TryParse(System.ReadOnlySpan<System.Char> s, out System.Byte result)`
+- `System.Byte.TryParse(System.ReadOnlySpan<System.Char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Byte result)`
+- `System.Byte.TryParse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider, out System.Byte result)`
 - `System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>.GetOrAdd<TArg>(TKey key, System.Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) where TArg : allows ref struct`
 - `System.Collections.Generic.CollectionExtensions.AddRange<T>(this System.Collections.Generic.List<T> list, params System.ReadOnlySpan<T> source)`
 - `System.Collections.Generic.CollectionExtensions.AsReadOnly<T>(this System.Collections.Generic.IList<T> list)`
@@ -142,7 +151,25 @@ By default, all needed polyfills are generated. You can configure which polyfill
 - `System.Convert.ToHexStringLower(System.Byte[] inArray)`
 - `System.Convert.ToHexStringLower(System.Byte[] inArray, System.Int32 offset, System.Int32 length)`
 - `System.Convert.ToHexStringLower(System.ReadOnlySpan<System.Byte> bytes)`
+- `System.Decimal.Parse(System.ReadOnlySpan<System.Byte> utf8Text, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Number], [System.IFormatProvider? provider = null])`
+- `System.Decimal.Parse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider)`
+- `System.Decimal.Parse(System.ReadOnlySpan<System.Char> s, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Number], [System.IFormatProvider? provider = null])`
+- `System.Decimal.Parse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider)`
+- `System.Decimal.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Decimal result)`
+- `System.Decimal.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider, out System.Decimal result)`
+- `System.Decimal.TryParse(System.ReadOnlySpan<System.Char> s, out System.Decimal result)`
+- `System.Decimal.TryParse(System.ReadOnlySpan<System.Char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Decimal result)`
+- `System.Decimal.TryParse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider, out System.Decimal result)`
 - `System.Diagnostics.Process.WaitForExitAsync([System.Threading.CancellationToken cancellationToken = default])`
+- `System.Double.Parse(System.ReadOnlySpan<System.Byte> utf8Text, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.AllowThousands | System.Globalization.NumberStyles.Float], [System.IFormatProvider? provider = null])`
+- `System.Double.Parse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider)`
+- `System.Double.Parse(System.ReadOnlySpan<System.Char> s, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.AllowThousands | System.Globalization.NumberStyles.Float], [System.IFormatProvider? provider = null])`
+- `System.Double.Parse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider)`
+- `System.Double.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Double result)`
+- `System.Double.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider, out System.Double result)`
+- `System.Double.TryParse(System.ReadOnlySpan<System.Char> s, out System.Double result)`
+- `System.Double.TryParse(System.ReadOnlySpan<System.Char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Double result)`
+- `System.Double.TryParse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider, out System.Double result)`
 - `System.Enum.GetNames<TEnum>() where TEnum : struct, System.Enum`
 - `System.Enum.GetValues<TEnum>() where TEnum : struct, System.Enum`
 - `System.Enum.IsDefined<TEnum>(TEnum value) where TEnum : struct, System.Enum`
@@ -168,10 +195,33 @@ By default, all needed polyfills are generated. You can configure which polyfill
 - `System.IO.TextReader.ReadAsync(System.Memory<System.Char> buffer, [System.Threading.CancellationToken cancellationToken = default])`
 - `System.IO.TextReader.ReadToEndAsync(System.Threading.CancellationToken cancellationToken)`
 - `System.IO.TextWriter.WriteAsync(System.ReadOnlyMemory<System.Char> buffer, [System.Threading.CancellationToken cancellationToken = default])`
+- `System.Int16.Parse(System.ReadOnlySpan<System.Byte> utf8Text, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.Int16.Parse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider)`
+- `System.Int16.Parse(System.ReadOnlySpan<System.Char> s, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.Int16.Parse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider)`
+- `System.Int16.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int16 result)`
+- `System.Int16.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider, out System.Int16 result)`
+- `System.Int16.TryParse(System.ReadOnlySpan<System.Char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int16 result)`
+- `System.Int16.TryParse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider, out System.Int16 result)`
+- `System.Int16.TryParse(System.ReadOnlySpan<System.Char> s, out System.Int16 result)`
+- `System.Int32.Parse(System.ReadOnlySpan<System.Byte> utf8Text, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.Int32.Parse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider)`
+- `System.Int32.Parse(System.ReadOnlySpan<System.Char> s, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.Int32.Parse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider)`
 - `System.Int32.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int32 result)`
 - `System.Int32.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider, out System.Int32 result)`
 - `System.Int32.TryParse(System.ReadOnlySpan<System.Char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int32 result)`
 - `System.Int32.TryParse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider, out System.Int32 result)`
+- `System.Int32.TryParse(System.ReadOnlySpan<System.Char> s, out System.Int32 result)`
+- `System.Int64.Parse(System.ReadOnlySpan<System.Byte> utf8Text, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.Int64.Parse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider)`
+- `System.Int64.Parse(System.ReadOnlySpan<System.Char> s, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.Int64.Parse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider)`
+- `System.Int64.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int64 result)`
+- `System.Int64.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider, out System.Int64 result)`
+- `System.Int64.TryParse(System.ReadOnlySpan<System.Char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int64 result)`
+- `System.Int64.TryParse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider, out System.Int64 result)`
+- `System.Int64.TryParse(System.ReadOnlySpan<System.Char> s, out System.Int64 result)`
 - `System.Linq.AsyncEnumerable.AggregateAsync<TSource>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TSource>> func, [System.Threading.CancellationToken cancellationToken = default])`
 - `System.Linq.AsyncEnumerable.AggregateAsync<TSource>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, System.Func<TSource, TSource, TSource> func, [System.Threading.CancellationToken cancellationToken = default])`
 - `System.Linq.AsyncEnumerable.AggregateAsync<TSource, TAccumulate>(this System.Collections.Generic.IAsyncEnumerable<TSource> source, TAccumulate seed, System.Func<TAccumulate, TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TAccumulate>> func, [System.Threading.CancellationToken cancellationToken = default])`
@@ -386,8 +436,26 @@ By default, all needed polyfills are generated. You can configure which polyfill
 - `System.OperatingSystem.IsMacOS()`
 - `System.OperatingSystem.IsWindows()`
 - `System.OperatingSystem.IsWindowsVersionAtLeast(System.Int32 major, [System.Int32 minor = 0], [System.Int32 build = 0], [System.Int32 revision = 0])`
+- `System.SByte.Parse(System.ReadOnlySpan<System.Byte> utf8Text, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.SByte.Parse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider)`
+- `System.SByte.Parse(System.ReadOnlySpan<System.Char> s, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.SByte.Parse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider)`
+- `System.SByte.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.SByte result)`
+- `System.SByte.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider, out System.SByte result)`
+- `System.SByte.TryParse(System.ReadOnlySpan<System.Char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.SByte result)`
+- `System.SByte.TryParse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider, out System.SByte result)`
+- `System.SByte.TryParse(System.ReadOnlySpan<System.Char> s, out System.SByte result)`
 - `System.Security.Cryptography.MD5.HashData(System.ReadOnlySpan<System.Byte> source)`
 - `System.Security.Cryptography.SHA256.HashData(System.ReadOnlySpan<System.Byte> source)`
+- `System.Single.Parse(System.ReadOnlySpan<System.Byte> utf8Text, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.AllowThousands | System.Globalization.NumberStyles.Float], [System.IFormatProvider? provider = null])`
+- `System.Single.Parse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider)`
+- `System.Single.Parse(System.ReadOnlySpan<System.Char> s, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.AllowThousands | System.Globalization.NumberStyles.Float], [System.IFormatProvider? provider = null])`
+- `System.Single.Parse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider)`
+- `System.Single.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Single result)`
+- `System.Single.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider, out System.Single result)`
+- `System.Single.TryParse(System.ReadOnlySpan<System.Char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Single result)`
+- `System.Single.TryParse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider, out System.Single result)`
+- `System.Single.TryParse(System.ReadOnlySpan<System.Char> s, out System.Single result)`
 - `System.String.Concat(System.ReadOnlySpan<System.Char> str0, System.ReadOnlySpan<System.Char> str1)`
 - `System.String.Concat(System.ReadOnlySpan<System.Char> str0, System.ReadOnlySpan<System.Char> str1, System.ReadOnlySpan<System.Char> str2)`
 - `System.String.Concat(System.ReadOnlySpan<System.Char> str0, System.ReadOnlySpan<System.Char> str1, System.ReadOnlySpan<System.Char> str2, System.ReadOnlySpan<System.Char> str3)`
@@ -440,6 +508,33 @@ By default, all needed polyfills are generated. You can configure which polyfill
 - `System.Type.GetConstructor(System.Reflection.BindingFlags bindingAttr, System.Type[] types)`
 - `System.Type.GetMethod(System.String name, System.Reflection.BindingFlags bindingAttr, System.Type[] types)`
 - `System.Type.IsAssignableTo(System.Type? targetType)`
+- `System.UInt16.Parse(System.ReadOnlySpan<System.Byte> utf8Text, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.UInt16.Parse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider)`
+- `System.UInt16.Parse(System.ReadOnlySpan<System.Char> s, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.UInt16.Parse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider)`
+- `System.UInt16.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UInt16 result)`
+- `System.UInt16.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider, out System.UInt16 result)`
+- `System.UInt16.TryParse(System.ReadOnlySpan<System.Char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UInt16 result)`
+- `System.UInt16.TryParse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider, out System.UInt16 result)`
+- `System.UInt16.TryParse(System.ReadOnlySpan<System.Char> s, out System.UInt16 result)`
+- `System.UInt32.Parse(System.ReadOnlySpan<System.Byte> utf8Text, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.UInt32.Parse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider)`
+- `System.UInt32.Parse(System.ReadOnlySpan<System.Char> s, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.UInt32.Parse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider)`
+- `System.UInt32.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UInt32 result)`
+- `System.UInt32.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider, out System.UInt32 result)`
+- `System.UInt32.TryParse(System.ReadOnlySpan<System.Char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UInt32 result)`
+- `System.UInt32.TryParse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider, out System.UInt32 result)`
+- `System.UInt32.TryParse(System.ReadOnlySpan<System.Char> s, out System.UInt32 result)`
+- `System.UInt64.Parse(System.ReadOnlySpan<System.Byte> utf8Text, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.UInt64.Parse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider)`
+- `System.UInt64.Parse(System.ReadOnlySpan<System.Char> s, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
+- `System.UInt64.Parse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider)`
+- `System.UInt64.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UInt64 result)`
+- `System.UInt64.TryParse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider, out System.UInt64 result)`
+- `System.UInt64.TryParse(System.ReadOnlySpan<System.Char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UInt64 result)`
+- `System.UInt64.TryParse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider, out System.UInt64 result)`
+- `System.UInt64.TryParse(System.ReadOnlySpan<System.Char> s, out System.UInt64 result)`
 
 ### Properties (4)
 


### PR DESCRIPTION
Introduce polyfill extension methods for `Int16`, `Int32`, `Int64`, `UInt16`, `UInt32`, `UInt64`, `Byte`, `SByte`, and `Decimal` to support `Parse` and `TryParse` from `ReadOnlySpan<byte>` and `ReadOnlySpan<char>`, matching .NET 8+ APIs. Methods convert spans to strings and use existing overloads, with UTF-8 decoding for byte spans. Update README and method list to document new overloads. Enables span-based parsing on older .NET versions.