### PR TITLE
test: replace ping with dotnet --version to avoid console window

### DIFF
--- a/Meziantou.Polyfill.Tests/SystemDiagnosticsTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemDiagnosticsTests.cs
@@ -22,9 +22,11 @@ public class SystemDiagnosticsTests
     {
         var psi = new ProcessStartInfo
         {
-            FileName = Environment.OSVersion.Platform == PlatformID.Win32NT ? "ping.exe" : "ping",
-            Arguments = Environment.OSVersion.Platform == PlatformID.Win32NT ? "127.0.0.1 -n 5" : "127.0.0.1 -c 5",
+            FileName = "dotnet",
+            Arguments = "--version",
             CreateNoWindow = true,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
         };
 
         var process = Process.Start(psi);


### PR DESCRIPTION
The `Process_WaitForExitAsync` test uses `ping` to spawn a child process, which opens a visible console window on Windows — disruptive when running tests locally.

This replaces `ping` with `dotnet --version`, which is always available in the test environment and produces no visible window. The change also explicitly sets `UseShellExecute = false` and `RedirectStandardOutput = true` to ensure the process runs silently. As a side benefit, the test now completes instantly instead of waiting for 5 ICMP pings.