### PR TITLE
Add ReadOnlySpan<char> TryParse regression tests

### DIFF
--- a/Meziantou.Polyfill.Tests/SystemTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemTests.cs
@@ -1358,6 +1358,19 @@ public class SystemTests
     }
 
     [Fact]
+    public void Double_TryParse_ReadOnlySpan_Char_NumberStyles_IFormatProvider()
+    {
+        Assert.True(double.TryParse("123.456".AsSpan(), NumberStyles.Float, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(123.456d, result, 3);
+
+        Assert.False(double.TryParse("ABC".AsSpan(), NumberStyles.Float, CultureInfo.InvariantCulture, out result));
+        Assert.Equal(0d, result);
+
+        Assert.True(double.TryParse("42.5".AsSpan(), NumberStyles.Float, null, out result));
+        Assert.Equal(42.5d, result, 1);
+    }
+
+    [Fact]
     public void Double_TryParse_ReadOnlySpan_Byte_IFormatProvider()
     {
         // Basic parsing from UTF8
@@ -1818,6 +1831,22 @@ public class SystemTests
         ReadOnlySpan<byte> utf8Data = "7FFFFFFFFFFFFFFF"u8;
         var result = long.Parse(utf8Data, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
         Assert.Equal(9223372036854775807L, result);
+    }
+
+    [Fact]
+    public void Int64_TryParse_ReadOnlySpan_Char_NumberStyles_IFormatProvider()
+    {
+        Assert.True(long.TryParse("7FFFFFFFFFFFFFFF".AsSpan(), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(9223372036854775807L, result);
+
+        Assert.True(long.TryParse("-42".AsSpan(), NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out result));
+        Assert.Equal(-42L, result);
+
+        Assert.False(long.TryParse("ABC".AsSpan(), NumberStyles.Integer, CultureInfo.InvariantCulture, out result));
+        Assert.Equal(0L, result);
+
+        Assert.True(long.TryParse("17".AsSpan(), NumberStyles.Integer, null, out result));
+        Assert.Equal(17L, result);
     }
 
     [Fact]


### PR DESCRIPTION
## Why
`int`/`long`/`double` span-based `TryParse` overloads are required on older TFMs so callers can drop `#if NETSTANDARD2_0` string-conversion fallbacks.

## What changed
Added regression tests in `SystemTests` to cover the span + `NumberStyles` + `IFormatProvider` overloads for:
- `double.TryParse(ReadOnlySpan<char>, NumberStyles, IFormatProvider, out ...)`
- `long.TryParse(ReadOnlySpan<char>, NumberStyles, IFormatProvider, out ...)`

`int.TryParse(ReadOnlySpan<char>, NumberStyles, IFormatProvider, out ...)` already had coverage in this suite.

## Notes
No product code changes were required here; the polyfills are already present. This PR locks coverage so these overloads remain available and the consumer-side `#if` can be removed safely.