### PR TITLE
Add HttpContent.LoadIntoBufferAsync cancellation polyfills

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.Net.Http.HttpContent.LoadIntoBufferAsync(System.Int64,System.Threading.CancellationToken).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Net.Http.HttpContent.LoadIntoBufferAsync(System.Int64,System.Threading.CancellationToken).cs
@@ -1,0 +1,12 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+static partial class PolyfillExtensions
+{
+    public static Task LoadIntoBufferAsync(this HttpContent httpContent, long maxBufferSize, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return httpContent.LoadIntoBufferAsync(maxBufferSize);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Net.Http.HttpContent.LoadIntoBufferAsync(System.Threading.CancellationToken).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Net.Http.HttpContent.LoadIntoBufferAsync(System.Threading.CancellationToken).cs
@@ -1,0 +1,12 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+static partial class PolyfillExtensions
+{
+    public static Task LoadIntoBufferAsync(this HttpContent httpContent, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return httpContent.LoadIntoBufferAsync();
+    }
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -1911,6 +1911,14 @@
       "net9.0",
       "net10.0"
     ],
+    "M:System.Net.Http.HttpContent.LoadIntoBufferAsync(System.Int64,System.Threading.CancellationToken)": [
+      "net9.0",
+      "net10.0"
+    ],
+    "M:System.Net.Http.HttpContent.LoadIntoBufferAsync(System.Threading.CancellationToken)": [
+      "net9.0",
+      "net10.0"
+    ],
     "M:System.Net.Http.HttpContent.ReadAsByteArrayAsync(System.Threading.CancellationToken)": [
       "net6.0",
       "net7.0",

--- a/Meziantou.Polyfill.Tests/SystemNetHttpTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemNetHttpTests.cs
@@ -56,6 +56,24 @@ public class SystemNetHttpTests
     }
 
     [Fact]
+    public async Task HttpContent_LoadIntoBufferAsync()
+    {
+        var content = new ByteArrayContent([1, 2, 3]);
+        await content.LoadIntoBufferAsync(CancellationToken.None);
+        var result = await content.ReadAsByteArrayAsync(CancellationToken.None);
+        Assert.Equal([1, 2, 3], result);
+    }
+
+    [Fact]
+    public async Task HttpContent_LoadIntoBufferAsync_WithMaxBufferSize()
+    {
+        var content = new ByteArrayContent([1, 2, 3]);
+        await content.LoadIntoBufferAsync(maxBufferSize: 3, CancellationToken.None);
+        var result = await content.ReadAsByteArrayAsync(CancellationToken.None);
+        Assert.Equal([1, 2, 3], result);
+    }
+
+    [Fact]
     public void HttpMethod_Query()
     {
         var queryMethod = HttpMethod.Query;

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.109</Version>
+    <Version>1.0.110</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (526)
+### Methods (528)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -493,6 +493,8 @@ The filtering logic works as follows:
 - `System.Net.Http.HttpContent.CopyToAsync(System.IO.Stream stream, System.Net.TransportContext? context)`
 - `System.Net.Http.HttpContent.CopyToAsync(System.IO.Stream stream, System.Net.TransportContext? context, System.Threading.CancellationToken cancellationToken)`
 - `System.Net.Http.HttpContent.CopyToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken)`
+- `System.Net.Http.HttpContent.LoadIntoBufferAsync(System.Int64 maxBufferSize, System.Threading.CancellationToken cancellationToken)`
+- `System.Net.Http.HttpContent.LoadIntoBufferAsync(System.Threading.CancellationToken cancellationToken)`
 - `System.Net.Http.HttpContent.ReadAsByteArrayAsync(System.Threading.CancellationToken cancellationToken)`
 - `System.Net.Http.HttpContent.ReadAsStream()`
 - `System.Net.Http.HttpContent.ReadAsStream(System.Threading.CancellationToken cancellationToken)`


### PR DESCRIPTION
## Why
`HttpContent.LoadIntoBufferAsync` gained cancellation-token overloads in newer TFMs. Adding polyfills for these overloads keeps call sites consistent when multi-targeting older frameworks.

## What changed
- Added polyfills for:
  - `HttpContent.LoadIntoBufferAsync(CancellationToken)`
  - `HttpContent.LoadIntoBufferAsync(long maxBufferSize, CancellationToken)`
- Implemented both by honoring cancellation up front and delegating to existing framework overloads.
- Added `SystemNetHttpTests` coverage for both overloads.
- Regenerated polyfill metadata/docs updates (`polyfill-supported-versions.json`, `README.md`) and bumped package version to `1.0.110`.

## Notes
This follows the existing `HttpContent` polyfill pattern used for other cancellation-token overloads in this repository.