### PR TITLE
Add ReadOnlySpan<T>.StartsWith(T) polyfills

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.MemoryExtensions.StartsWith``1(System.ReadOnlySpan{``0},``0).cs
+++ b/Meziantou.Polyfill.Editor/M;System.MemoryExtensions.StartsWith``1(System.ReadOnlySpan{``0},``0).cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+static partial class PolyfillExtensions
+{
+    public static bool StartsWith<T>(this ReadOnlySpan<T> span, T value) where T : IEquatable<T>?
+    {
+        if (span.Length == 0)
+            return false;
+
+        return EqualityComparer<T>.Default.Equals(span[0], value);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.MemoryExtensions.StartsWith``1(System.ReadOnlySpan{``0},``0,System.Collections.Generic.IEqualityComparer{``0}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.MemoryExtensions.StartsWith``1(System.ReadOnlySpan{``0},``0,System.Collections.Generic.IEqualityComparer{``0}).cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+
+static partial class PolyfillExtensions
+{
+    public static bool StartsWith<T>(this ReadOnlySpan<T> span, T value, IEqualityComparer<T>? comparer = default)
+    {
+        if (span.Length == 0)
+            return false;
+
+        comparer ??= EqualityComparer<T>.Default;
+        return comparer.Equals(span[0], value);
+    }
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -1866,6 +1866,13 @@
       "net9.0",
       "net10.0"
     ],
+    "M:System.MemoryExtensions.StartsWith\u0060\u00601(System.ReadOnlySpan{\u0060\u00600},\u0060\u00600)": [
+      "net9.0",
+      "net10.0"
+    ],
+    "M:System.MemoryExtensions.StartsWith\u0060\u00601(System.ReadOnlySpan{\u0060\u00600},\u0060\u00600,System.Collections.Generic.IEqualityComparer{\u0060\u00600})": [
+      "net10.0"
+    ],
     "M:System.Net.Http.HttpContent.CopyTo(System.IO.Stream,System.Net.TransportContext,System.Threading.CancellationToken)": [
       "net6.0",
       "net7.0",

--- a/Meziantou.Polyfill.Tests/SystemMemoryExtensionsTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemMemoryExtensionsTests.cs
@@ -25,4 +25,19 @@ public class SystemMemoryExtensionsTests
         Assert.Equal(2, ((Span<int>)[0, 1]).CommonPrefixLength([0, 1, 2]));
     }
 
+    [Fact]
+    public void StartsWith_Value()
+    {
+        Assert.False(((ReadOnlySpan<int>)[]).StartsWith(0));
+        Assert.True(((ReadOnlySpan<int>)[0, 1]).StartsWith(0));
+        Assert.False(((ReadOnlySpan<int>)[0, 1]).StartsWith(1));
+    }
+
+    [Fact]
+    public void StartsWith_Value_WithComparer()
+    {
+        Assert.False(((ReadOnlySpan<string>)[]).StartsWith("a", StringComparer.OrdinalIgnoreCase));
+        Assert.True(((ReadOnlySpan<string>)["a", "b"]).StartsWith("A", StringComparer.OrdinalIgnoreCase));
+        Assert.False(((ReadOnlySpan<string>)["a", "b"]).StartsWith("A", StringComparer.Ordinal));
+    }
 }

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.110</Version>
+    <Version>1.0.111</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (528)
+### Methods (530)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -488,6 +488,8 @@ The filtering logic works as follows:
 - `System.MemoryExtensions.IndexOfAnyExcept<T>(this System.Span<T> span, T value) where T : System.IEquatable<T>?`
 - `System.MemoryExtensions.IndexOfAnyExcept<T>(this System.Span<T> span, T value0, T value1) where T : System.IEquatable<T>?`
 - `System.MemoryExtensions.IndexOfAnyExcept<T>(this System.Span<T> span, T value0, T value1, T value2) where T : System.IEquatable<T>?`
+- `System.MemoryExtensions.StartsWith<T>(this System.ReadOnlySpan<T> span, T value) where T : System.IEquatable<T>?`
+- `System.MemoryExtensions.StartsWith<T>(this System.ReadOnlySpan<T> span, T value, [System.Collections.Generic.IEqualityComparer<T>? comparer = null])`
 - `System.Net.Http.HttpContent.CopyTo(System.IO.Stream stream, System.Net.TransportContext? context, System.Threading.CancellationToken cancellationToken)`
 - `System.Net.Http.HttpContent.CopyToAsync(System.IO.Stream stream)`
 - `System.Net.Http.HttpContent.CopyToAsync(System.IO.Stream stream, System.Net.TransportContext? context)`


### PR DESCRIPTION
## Why
`System.MemoryExtensions` includes `StartsWith` overloads for a single value, and those APIs were missing from the polyfill surface.

## What changed
- Added `ReadOnlySpan<T>.StartsWith(T value)` polyfill constrained to `T : IEquatable<T>?`.
- Added `ReadOnlySpan<T>.StartsWith(T value, IEqualityComparer<T>? comparer = default)` polyfill.
- Implemented both overloads with empty-span handling and first-element comparison semantics.
- Added tests covering empty span, match/non-match, and comparer behavior.
- Regenerated supported API metadata and README entries.
- Bumped package version to `1.0.111`.

## Notes
No PR template is present in `.github/`, so this description is freeform.