### PR TITLE
Add polyfills for System.Array.Fill

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.Array.Fill``1(``0[],``0).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Array.Fill``1(``0[],``0).cs
@@ -1,0 +1,15 @@
+partial class PolyfillExtensions
+{
+    extension(System.Array)
+    {
+        public static void Fill<T>(T[] array, T value)
+        {
+            if (array is null)
+            {
+                throw new System.ArgumentNullException(nameof(array));
+            }
+
+            System.Array.Fill(array, value, 0, array.Length);
+        }
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Array.Fill``1(``0[],``0,System.Int32,System.Int32).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Array.Fill``1(``0[],``0,System.Int32,System.Int32).cs
@@ -1,0 +1,29 @@
+partial class PolyfillExtensions
+{
+    extension(System.Array)
+    {
+        public static void Fill<T>(T[] array, T value, int startIndex, int count)
+        {
+            if (array is null)
+            {
+                throw new System.ArgumentNullException(nameof(array));
+            }
+
+            if ((uint)startIndex > (uint)array.Length)
+            {
+                throw new System.ArgumentOutOfRangeException(nameof(startIndex));
+            }
+
+            if ((uint)count > (uint)(array.Length - startIndex))
+            {
+                throw new System.ArgumentOutOfRangeException(nameof(count));
+            }
+
+            int end = startIndex + count;
+            for (int i = startIndex; i < end; i++)
+            {
+                array[i] = value;
+            }
+        }
+    }
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -89,6 +89,22 @@
       "net9.0",
       "net10.0"
     ],
+    "M:System.Array.Fill\u0060\u00601(\u0060\u00600[],\u0060\u00600)": [
+      "netstandard2.1",
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
+    "M:System.Array.Fill\u0060\u00601(\u0060\u00600[],\u0060\u00600,System.Int32,System.Int32)": [
+      "netstandard2.1",
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
     "M:System.BitConverter.ToInt16(System.ReadOnlySpan{System.Byte})": [
       "netstandard2.1",
       "net6.0",

--- a/Meziantou.Polyfill.Tests/SystemArrayTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemArrayTests.cs
@@ -1,0 +1,74 @@
+using System;
+using Xunit;
+
+namespace Meziantou.Polyfill.Tests;
+
+public sealed class SystemArrayTests
+{
+    [Fact]
+    public void Fill_AllElements()
+    {
+        var values = new[] { 1, 2, 3, 4 };
+        Array.Fill(values, 42);
+
+        Assert.Equal(new[] { 42, 42, 42, 42 }, values);
+    }
+
+    [Fact]
+    public void Fill_Range()
+    {
+        var values = new[] { 1, 2, 3, 4, 5 };
+        Array.Fill(values, 9, 1, 3);
+
+        Assert.Equal(new[] { 1, 9, 9, 9, 5 }, values);
+    }
+
+    [Fact]
+    public void Fill_NullArray_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => Array.Fill<int>(null!, 1));
+    }
+
+    [Fact]
+    public void Fill_Range_NullArray_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => Array.Fill<int>(null!, 1, 0, 0));
+    }
+
+    [Fact]
+    public void Fill_Range_StartIndexNegative_Throws()
+    {
+        var values = new[] { 1, 2, 3 };
+        Assert.Throws<ArgumentOutOfRangeException>(() => Array.Fill(values, 0, -1, 1));
+    }
+
+    [Fact]
+    public void Fill_Range_StartIndexTooLarge_Throws()
+    {
+        var values = new[] { 1, 2, 3 };
+        Assert.Throws<ArgumentOutOfRangeException>(() => Array.Fill(values, 0, 4, 0));
+    }
+
+    [Fact]
+    public void Fill_Range_CountNegative_Throws()
+    {
+        var values = new[] { 1, 2, 3 };
+        Assert.Throws<ArgumentOutOfRangeException>(() => Array.Fill(values, 0, 0, -1));
+    }
+
+    [Fact]
+    public void Fill_Range_CountTooLarge_Throws()
+    {
+        var values = new[] { 1, 2, 3 };
+        Assert.Throws<ArgumentOutOfRangeException>(() => Array.Fill(values, 0, 1, 3));
+    }
+
+    [Fact]
+    public void Fill_Range_EmptySegmentAtEnd_DoesNotThrow()
+    {
+        var values = new[] { 1, 2, 3 };
+        Array.Fill(values, 0, 3, 0);
+
+        Assert.Equal(new[] { 1, 2, 3 }, values);
+    }
+}

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.111</Version>
+    <Version>1.0.112</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (530)
+### Methods (532)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -139,6 +139,8 @@ The filtering logic works as follows:
 - `System.ArgumentOutOfRangeException.ThrowIfNegative<T>(T value, [System.String? paramName = null]) where T : System.Numerics.INumberBase<T>`
 - `System.ArgumentOutOfRangeException.ThrowIfNotEqual<T>(T value, T other, [System.String? paramName = null])`
 - `System.ArgumentOutOfRangeException.ThrowIfZero<T>(T value, [System.String? paramName = null]) where T : System.Numerics.INumberBase<T>`
+- `System.Array.Fill<T>(T[] array, T value)`
+- `System.Array.Fill<T>(T[] array, T value, System.Int32 startIndex, System.Int32 count)`
 - `System.BitConverter.ToInt16(System.ReadOnlySpan<System.Byte> value)`
 - `System.BitConverter.ToInt32(System.ReadOnlySpan<System.Byte> value)`
 - `System.Byte.Parse(System.ReadOnlySpan<System.Byte> utf8Text, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`


### PR DESCRIPTION
`System.Array.Fill` is not available on older target frameworks, which makes shared code harder to keep multi-targeted. This change adds the missing API surface so existing `Array.Fill(...)` calls continue to compile and behave consistently.

## What changed
- Added polyfills for both overloads:
  - `Array.Fill<T>(T[] array, T value)`
  - `Array.Fill<T>(T[] array, T value, int startIndex, int count)`
- Matched core argument validation behavior (null and range checks) and filled values in-place.
- Added `SystemArrayTests` covering full-array fill, ranged fill, and exception cases.
- Regenerated polyfill metadata and updated supported members documentation.
- Bumped package version from `1.0.111` to `1.0.112`.

## Notes for reviewers
The one-parameter overload delegates to the ranged overload so validation and fill behavior are centralized and consistent.