### PR TITLE
Add String.GetHashCode overloads for ReadOnlySpan<char>

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.String.GetHashCode(System.ReadOnlySpan{System.Char}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.String.GetHashCode(System.ReadOnlySpan{System.Char}).cs
@@ -1,0 +1,12 @@
+using System;
+
+static partial class PolyfillExtensions
+{
+    extension(string)
+    {
+        public static int GetHashCode(ReadOnlySpan<char> value)
+        {
+            return value.ToString().GetHashCode();
+        }
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.String.GetHashCode(System.ReadOnlySpan{System.Char},System.StringComparison).cs
+++ b/Meziantou.Polyfill.Editor/M;System.String.GetHashCode(System.ReadOnlySpan{System.Char},System.StringComparison).cs
@@ -1,0 +1,12 @@
+using System;
+
+static partial class PolyfillExtensions
+{
+    extension(string)
+    {
+        public static int GetHashCode(ReadOnlySpan<char> value, StringComparison comparisonType)
+        {
+            return value.ToString().GetHashCode(comparisonType);
+        }
+    }
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -2349,6 +2349,20 @@
       "net9.0",
       "net10.0"
     ],
+    "M:System.String.GetHashCode(System.ReadOnlySpan{System.Char})": [
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
+    "M:System.String.GetHashCode(System.ReadOnlySpan{System.Char},System.StringComparison)": [
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
     "M:System.String.GetHashCode(System.StringComparison)": [
       "netstandard2.1",
       "net6.0",

--- a/Meziantou.Polyfill.Tests/SystemTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemTests.cs
@@ -81,6 +81,8 @@ public class SystemTests
     {
         Assert.Equal("test".GetHashCode(), "test".GetHashCode(StringComparison.Ordinal));
         Assert.Equal(StringComparer.OrdinalIgnoreCase.GetHashCode("Test"), "test".GetHashCode(StringComparison.OrdinalIgnoreCase));
+        Assert.Equal("test".GetHashCode(), string.GetHashCode("test".AsSpan()));
+        Assert.Equal(StringComparer.OrdinalIgnoreCase.GetHashCode("Test"), string.GetHashCode("test".AsSpan(), StringComparison.OrdinalIgnoreCase));
 
     }
 

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.112</Version>
+    <Version>1.0.113</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (532)
+### Methods (534)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -561,6 +561,8 @@ The filtering logic works as follows:
 - `System.String.CopyTo(System.Span<System.Char> destination)`
 - `System.String.Create(System.IFormatProvider? provider, ref System.Runtime.CompilerServices.DefaultInterpolatedStringHandler handler)`
 - `System.String.EndsWith(System.Char value)`
+- `System.String.GetHashCode(System.ReadOnlySpan<System.Char> value)`
+- `System.String.GetHashCode(System.ReadOnlySpan<System.Char> value, System.StringComparison comparisonType)`
 - `System.String.GetHashCode(System.StringComparison comparisonType)`
 - `System.String.IndexOf(System.Char value, System.StringComparison comparisonType)`
 - `System.String.Join(System.Char separator, params System.Object?[] values)`


### PR DESCRIPTION
## Why
`string.GetHashCode(ReadOnlySpan<char>)` and `string.GetHashCode(ReadOnlySpan<char>, StringComparison)` are missing from the current polyfills. This adds coverage for the span-based APIs so consumers targeting older frameworks can use the same call sites.

## What changed
- Added a polyfill for `string.GetHashCode(ReadOnlySpan<char>)`.
- Added a polyfill for `string.GetHashCode(ReadOnlySpan<char>, StringComparison)`.
- Implemented both overloads as extension static members in `PolyfillExtensions` under the corresponding XML-doc-ID editor files.
- Extended `SystemTests.String_GetHashCode` to validate both new overloads against existing hash behavior.
- Bumped package version from `1.0.112` to `1.0.113`.

## Notes
The implementation converts the span to `string` and delegates to existing string hash code logic, matching existing polyfill style and comparison semantics.