### PR TITLE
Update NuGet package description

### DIFF
--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -13,7 +13,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <Description>Source Generator to help multi-targeting projects.</Description>
+    <Description>Meziantou.Polyfill generates source-only polyfills for C# features, so runtime-agnostic language capabilities work on older target frameworks.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>SourceGenerator,Roslyn,Polyfill</PackageTags>


### PR DESCRIPTION
The current package description is generic and does not clearly communicate the main value of Meziantou.Polyfill. This change clarifies what the package provides for users targeting older frameworks.

It updates the `.csproj` package metadata description to explicitly state that the package generates source-only polyfills for C# features, enabling runtime-agnostic language capabilities on downlevel target frameworks.