### PR TITLE
Add ReadOnlySpan<char>.IndexOfAny(SearchValues<string>) polyfill

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.MemoryExtensions.IndexOfAny(System.ReadOnlySpan{System.Char},System.Buffers.SearchValues{System.String}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.MemoryExtensions.IndexOfAny(System.ReadOnlySpan{System.Char},System.Buffers.SearchValues{System.String}).cs
@@ -1,0 +1,26 @@
+using System;
+using System.Buffers;
+
+static partial class PolyfillExtensions
+{
+    public static int IndexOfAny(this ReadOnlySpan<char> span, SearchValues<string> values)
+    {
+        if (values is null)
+            throw new ArgumentNullException(nameof(values));
+
+        if (values.Contains(string.Empty))
+            return 0;
+
+        for (var start = 0; start < span.Length; start++)
+        {
+            var remainingLength = span.Length - start;
+            for (var length = 1; length <= remainingLength; length++)
+            {
+                if (values.Contains(span.Slice(start, length).ToString()))
+                    return start;
+            }
+        }
+
+        return -1;
+    }
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -1834,6 +1834,10 @@
       "net9.0",
       "net10.0"
     ],
+    "M:System.MemoryExtensions.IndexOfAny(System.ReadOnlySpan{System.Char},System.Buffers.SearchValues{System.String})": [
+      "net9.0",
+      "net10.0"
+    ],
     "M:System.MemoryExtensions.IndexOfAnyExcept\u0060\u00601(System.ReadOnlySpan{\u0060\u00600},System.ReadOnlySpan{\u0060\u00600})": [
       "net7.0",
       "net8.0",

--- a/Meziantou.Polyfill.Tests/SystemMemoryExtensionsTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemMemoryExtensionsTests.cs
@@ -40,4 +40,23 @@ public class SystemMemoryExtensionsTests
         Assert.True(((ReadOnlySpan<string>)["a", "b"]).StartsWith("A", StringComparer.OrdinalIgnoreCase));
         Assert.False(((ReadOnlySpan<string>)["a", "b"]).StartsWith("A", StringComparer.Ordinal));
     }
+
+#if NET9_0_OR_GREATER
+    [Fact]
+    public void IndexOfAny_SearchValues_String_Ordinal()
+    {
+        var values = System.Buffers.SearchValues.Create(["hello", "world"], StringComparison.Ordinal);
+        Assert.Equal(2, "xxhello yy".AsSpan().IndexOfAny(values));
+        Assert.Equal(8, "xxhEllo world".AsSpan().IndexOfAny(values));
+        Assert.Equal(-1, "xxhEllo yy".AsSpan().IndexOfAny(values));
+    }
+
+    [Fact]
+    public void IndexOfAny_SearchValues_String_OrdinalIgnoreCase()
+    {
+        var values = System.Buffers.SearchValues.Create(["hello", "world"], StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(2, "xxHeLlO yy".AsSpan().IndexOfAny(values));
+        Assert.Equal(2, "xxWORLD yy".AsSpan().IndexOfAny(values));
+    }
+#endif
 }

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.113</Version>
+    <Version>1.0.114</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (534)
+### Methods (535)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -482,6 +482,7 @@ The filtering logic works as follows:
 - `System.MemoryExtensions.ContainsAny<T>(this System.Span<T> span, T value0, T value1, T value2) where T : System.IEquatable<T>?`
 - `System.MemoryExtensions.Contains<T>(this System.ReadOnlySpan<T> span, T value) where T : System.IEquatable<T>?`
 - `System.MemoryExtensions.Contains<T>(this System.Span<T> span, T value) where T : System.IEquatable<T>?`
+- `System.MemoryExtensions.IndexOfAny(this System.ReadOnlySpan<System.Char> span, System.Buffers.SearchValues<System.String> values)`
 - `System.MemoryExtensions.IndexOfAnyExcept<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> values) where T : System.IEquatable<T>?`
 - `System.MemoryExtensions.IndexOfAnyExcept<T>(this System.ReadOnlySpan<T> span, T value) where T : System.IEquatable<T>?`
 - `System.MemoryExtensions.IndexOfAnyExcept<T>(this System.ReadOnlySpan<T> span, T value0, T value1) where T : System.IEquatable<T>?`


### PR DESCRIPTION
## Why
`MemoryExtensions.IndexOfAny(ReadOnlySpan<char>, SearchValues<string>)` exists on newer runtimes, and projects targeting older frameworks need a compatible polyfill path for this API.

## What changed
- Added a new polyfill method:
  - `IndexOfAny(this ReadOnlySpan<char> span, SearchValues<string> values)`
- Implemented null checking and empty-string behavior (`0` when `values` contains `""`).
- Implemented matching by scanning the span and checking candidate substrings with `SearchValues<string>.Contains`.
- Added `SystemMemoryExtensionsTests` coverage for:
  - ordinal matching
  - ordinal ignore-case matching
  - no-match behavior
- Regenerated supported polyfill metadata and README list.
- Bumped package version from `1.0.113` to `1.0.114`.

## Notes
This is intentionally a straightforward compatibility implementation focused on correctness for the polyfill surface.

## Validation
- `dotnet run --project ./Meziantou.Polyfill.Generator/Meziantou.Polyfill.Generator.csproj`
- `dotnet build` (succeeds)
- `dotnet test`
  - net10.0 tests pass
  - .NET Framework test runs are aborted in this macOS environment due to missing `mono` host