### PR TITLE
Add IndexOfAny(ReadOnlySpan<T>, SearchValues<T>) polyfill

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.MemoryExtensions.IndexOfAny``1(System.ReadOnlySpan{``0},System.Buffers.SearchValues{``0}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.MemoryExtensions.IndexOfAny``1(System.ReadOnlySpan{``0},System.Buffers.SearchValues{``0}).cs
@@ -1,0 +1,19 @@
+using System;
+using System.Buffers;
+
+static partial class PolyfillExtensions
+{
+    public static int IndexOfAny<T>(this ReadOnlySpan<T> span, SearchValues<T> values) where T : IEquatable<T>?
+    {
+        if (values is null)
+            throw new ArgumentNullException(nameof(values));
+
+        for (var i = 0; i < span.Length; i++)
+        {
+            if (values.Contains(span[i]))
+                return i;
+        }
+
+        return -1;
+    }
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -1886,6 +1886,11 @@
       "net9.0",
       "net10.0"
     ],
+    "M:System.MemoryExtensions.IndexOfAny\u0060\u00601(System.ReadOnlySpan{\u0060\u00600},System.Buffers.SearchValues{\u0060\u00600})": [
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
     "M:System.MemoryExtensions.StartsWith\u0060\u00601(System.ReadOnlySpan{\u0060\u00600},\u0060\u00600)": [
       "net9.0",
       "net10.0"

--- a/Meziantou.Polyfill.Tests/SystemMemoryExtensionsTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemMemoryExtensionsTests.cs
@@ -43,6 +43,14 @@ public class SystemMemoryExtensionsTests
 
 #if NET9_0_OR_GREATER
     [Fact]
+    public void IndexOfAny_SearchValues_Char()
+    {
+        var values = System.Buffers.SearchValues.Create("ow");
+        Assert.Equal(4, "helloworld".AsSpan().IndexOfAny(values));
+        Assert.Equal(-1, "abcdef".AsSpan().IndexOfAny(values));
+    }
+
+    [Fact]
     public void IndexOfAny_SearchValues_String_Ordinal()
     {
         var values = System.Buffers.SearchValues.Create(["hello", "world"], StringComparison.Ordinal);

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.114</Version>
+    <Version>1.0.115</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (535)
+### Methods (536)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -491,6 +491,7 @@ The filtering logic works as follows:
 - `System.MemoryExtensions.IndexOfAnyExcept<T>(this System.Span<T> span, T value) where T : System.IEquatable<T>?`
 - `System.MemoryExtensions.IndexOfAnyExcept<T>(this System.Span<T> span, T value0, T value1) where T : System.IEquatable<T>?`
 - `System.MemoryExtensions.IndexOfAnyExcept<T>(this System.Span<T> span, T value0, T value1, T value2) where T : System.IEquatable<T>?`
+- `System.MemoryExtensions.IndexOfAny<T>(this System.ReadOnlySpan<T> span, System.Buffers.SearchValues<T> values) where T : System.IEquatable<T>?`
 - `System.MemoryExtensions.StartsWith<T>(this System.ReadOnlySpan<T> span, T value) where T : System.IEquatable<T>?`
 - `System.MemoryExtensions.StartsWith<T>(this System.ReadOnlySpan<T> span, T value, [System.Collections.Generic.IEqualityComparer<T>? comparer = null])`
 - `System.Net.Http.HttpContent.CopyTo(System.IO.Stream stream, System.Net.TransportContext? context, System.Threading.CancellationToken cancellationToken)`


### PR DESCRIPTION
## Why
`ReadOnlySpan<char>.IndexOfAny(SearchValues<char>)` was missing from generated polyfills. Consumers targeting older frameworks could not use this API shape through Meziantou.Polyfill.

## What changed
- Added a new generic polyfill:
  - `System.MemoryExtensions.IndexOfAny<T>(this ReadOnlySpan<T> span, SearchValues<T> values) where T : IEquatable<T>?`
- This directly covers the requested `ReadOnlySpan<char> + SearchValues<char>` scenario.
- Added a focused test in `SystemMemoryExtensionsTests` for char search values.
- Regenerated metadata/output files, which updated:
  - `polyfill-supported-versions.json`
  - `README.md`
- Bumped package version to `1.0.115`.

## Notes
Validation was run with the required generator/build flow and net10 test targets. Full multi-target test execution is environment-limited here (missing `mono` and .NET 8/9 runtimes).