### PR TITLE
Add IndexOfAnyExcept(ReadOnlySpan<T>, SearchValues<T>) polyfill

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.MemoryExtensions.IndexOfAnyExcept``1(System.ReadOnlySpan{``0},System.Buffers.SearchValues{``0}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.MemoryExtensions.IndexOfAnyExcept``1(System.ReadOnlySpan{``0},System.Buffers.SearchValues{``0}).cs
@@ -1,0 +1,19 @@
+using System;
+using System.Buffers;
+
+static partial class PolyfillExtensions
+{
+    public static int IndexOfAnyExcept<T>(this ReadOnlySpan<T> span, SearchValues<T> values) where T : IEquatable<T>?
+    {
+        if (values is null)
+            throw new ArgumentNullException(nameof(values));
+
+        for (var i = 0; i < span.Length; i++)
+        {
+            if (!values.Contains(span[i]))
+                return i;
+        }
+
+        return -1;
+    }
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -1838,6 +1838,11 @@
       "net9.0",
       "net10.0"
     ],
+    "M:System.MemoryExtensions.IndexOfAnyExcept\u0060\u00601(System.ReadOnlySpan{\u0060\u00600},System.Buffers.SearchValues{\u0060\u00600})": [
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
     "M:System.MemoryExtensions.IndexOfAnyExcept\u0060\u00601(System.ReadOnlySpan{\u0060\u00600},System.ReadOnlySpan{\u0060\u00600})": [
       "net7.0",
       "net8.0",

--- a/Meziantou.Polyfill.Tests/SystemMemoryExtensionsTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemMemoryExtensionsTests.cs
@@ -51,6 +51,14 @@ public class SystemMemoryExtensionsTests
     }
 
     [Fact]
+    public void IndexOfAnyExcept_SearchValues_Char()
+    {
+        var values = System.Buffers.SearchValues.Create("he");
+        Assert.Equal(4, "heeelloworld".AsSpan().IndexOfAnyExcept(values));
+        Assert.Equal(-1, "eheeh".AsSpan().IndexOfAnyExcept(values));
+    }
+
+    [Fact]
     public void IndexOfAny_SearchValues_String_Ordinal()
     {
         var values = System.Buffers.SearchValues.Create(["hello", "world"], StringComparison.Ordinal);

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.115</Version>
+    <Version>1.0.116</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (536)
+### Methods (537)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -483,6 +483,7 @@ The filtering logic works as follows:
 - `System.MemoryExtensions.Contains<T>(this System.ReadOnlySpan<T> span, T value) where T : System.IEquatable<T>?`
 - `System.MemoryExtensions.Contains<T>(this System.Span<T> span, T value) where T : System.IEquatable<T>?`
 - `System.MemoryExtensions.IndexOfAny(this System.ReadOnlySpan<System.Char> span, System.Buffers.SearchValues<System.String> values)`
+- `System.MemoryExtensions.IndexOfAnyExcept<T>(this System.ReadOnlySpan<T> span, System.Buffers.SearchValues<T> values) where T : System.IEquatable<T>?`
 - `System.MemoryExtensions.IndexOfAnyExcept<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> values) where T : System.IEquatable<T>?`
 - `System.MemoryExtensions.IndexOfAnyExcept<T>(this System.ReadOnlySpan<T> span, T value) where T : System.IEquatable<T>?`
 - `System.MemoryExtensions.IndexOfAnyExcept<T>(this System.ReadOnlySpan<T> span, T value0, T value1) where T : System.IEquatable<T>?`


### PR DESCRIPTION
## Why
`MemoryExtensions.IndexOfAnyExcept<T>(ReadOnlySpan<T>, SearchValues<T>)` is available on newer TFMs but missing from the current polyfill surface. Adding it keeps `SearchValues<T>`-based APIs consistent with existing `IndexOfAny` and `IndexOfAnyExcept` overload support.

## What changed
- Added a new polyfill in `PolyfillExtensions` for:
  - `System.MemoryExtensions.IndexOfAnyExcept<T>(this ReadOnlySpan<T> span, System.Buffers.SearchValues<T> values)`
- Implementation follows existing project patterns:
  - throw `ArgumentNullException` when `values` is null
  - linear scan returning the first index whose element is **not** contained in `values`
  - return `-1` when all elements are contained
- Added test coverage in `SystemMemoryExtensionsTests` for matching and non-matching cases.
- Regenerated metadata/docs outputs and bumped package version patch:
  - `polyfill-supported-versions.json`
  - `README.md`
  - `Meziantou.Polyfill.csproj` version `1.0.115` -> `1.0.116`

## Notes
This is intentionally a straightforward implementation matching the existing `SearchValues<T>` polyfill style in this repository.