### PR TITLE
Add BitConverter.ToUInt16 / BitConverter.ToUInt32 polyfill

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.BitConverter.ToUInt16(System.ReadOnlySpan{System.Byte}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.BitConverter.ToUInt16(System.ReadOnlySpan{System.Byte}).cs
@@ -1,0 +1,12 @@
+using System;
+
+static partial class PolyfillExtensions
+{
+    extension(BitConverter)
+    {
+        public static ushort ToUInt16(ReadOnlySpan<byte> value)
+        {
+            return BitConverter.ToUInt16(value.ToArray(), 0);
+        }
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.BitConverter.ToUInt32(System.ReadOnlySpan{System.Byte}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.BitConverter.ToUInt32(System.ReadOnlySpan{System.Byte}).cs
@@ -1,0 +1,12 @@
+using System;
+
+static partial class PolyfillExtensions
+{
+    extension(BitConverter)
+    {
+        public static uint ToUInt32(ReadOnlySpan<byte> value)
+        {
+            return BitConverter.ToUInt32(value.ToArray(), 0);
+        }
+    }
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -121,6 +121,22 @@
       "net9.0",
       "net10.0"
     ],
+    "M:System.BitConverter.ToUInt16(System.ReadOnlySpan{System.Byte})": [
+      "netstandard2.1",
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
+    "M:System.BitConverter.ToUInt32(System.ReadOnlySpan{System.Byte})": [
+      "netstandard2.1",
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
     "M:System.Byte.Parse(System.ReadOnlySpan{System.Byte},System.Globalization.NumberStyles,System.IFormatProvider)": [
       "net8.0",
       "net9.0",

--- a/Meziantou.Polyfill.Tests/SystemTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemTests.cs
@@ -1255,18 +1255,18 @@ public class SystemTests
 
         // Test with little-endian bytes representing 256
         ReadOnlySpan<byte> data3 = [0x00, 0x01];
-        var result3 = BitConverter.ToUInt16(data3);
-        Assert.Equal(256u, result3);
+        var result2 = BitConverter.ToUInt16(data3);
+        Assert.Equal(256u, result2);
 
         // Test with little-endian bytes representing ushort.MaxValue (65535)
         ReadOnlySpan<byte> data4 = [0xFF, 0xFF];
-        var result4 = BitConverter.ToUInt16(data4);
-        Assert.Equal(ushort.MaxValue, result4);
+        var result3 = BitConverter.ToUInt16(data4);
+        Assert.Equal(ushort.MaxValue, result3);
 
         // Test with little-endian bytes representing ushort.MinValue (0)
         ReadOnlySpan<byte> data5 = [0x00, 0x00];
-        var result5 = BitConverter.ToUInt16(data5);
-        Assert.Equal(ushort.MinValue, result5);
+        var result4 = BitConverter.ToUInt16(data5);
+        Assert.Equal(ushort.MinValue, result4);
     }
 
     [Fact]
@@ -1279,18 +1279,18 @@ public class SystemTests
 
         // Test with little-endian bytes representing 256
         ReadOnlySpan<byte> data3 = [0x00, 0x01, 0x00, 0x00];
-        var result3 = BitConverter.ToUInt32(data3);
-        Assert.Equal(256u, result3);
+        var result2 = BitConverter.ToUInt32(data3);
+        Assert.Equal(256u, result2);
 
         // Test with little-endian bytes representing uint.MaxValue (4294967295)
         ReadOnlySpan<byte> data4 = [0xFF, 0xFF, 0xFF, 0xFF];
-        var result4 = BitConverter.ToUInt32(data4);
-        Assert.Equal(uint.MaxValue, result4);
+        var result3 = BitConverter.ToUInt32(data4);
+        Assert.Equal(uint.MaxValue, result3);
 
         // Test with little-endian bytes representing uint.MinValue (0)
         ReadOnlySpan<byte> data5 = [0x00, 0x00, 0x00, 0x00];
-        var result5 = BitConverter.ToUInt32(data5);
-        Assert.Equal(uint.MinValue, result5);
+        var result4 = BitConverter.ToUInt32(data5);
+        Assert.Equal(uint.MinValue, result4);
     }
 
     [Fact]

--- a/Meziantou.Polyfill.Tests/SystemTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemTests.cs
@@ -1246,6 +1246,54 @@ public class SystemTests
     }
 
     [Fact]
+    public void BitConverter_ToUInt16_ReadOnlySpan()
+    {
+        // Test with little-endian bytes representing 42
+        ReadOnlySpan<byte> data1 = [0x2A, 0x00];
+        var result1 = BitConverter.ToUInt16(data1);
+        Assert.Equal(42u, result1);
+
+        // Test with little-endian bytes representing 256
+        ReadOnlySpan<byte> data3 = [0x00, 0x01];
+        var result3 = BitConverter.ToUInt16(data3);
+        Assert.Equal(256u, result3);
+
+        // Test with little-endian bytes representing ushort.MaxValue (65535)
+        ReadOnlySpan<byte> data4 = [0xFF, 0xFF];
+        var result4 = BitConverter.ToUInt16(data4);
+        Assert.Equal(ushort.MaxValue, result4);
+
+        // Test with little-endian bytes representing ushort.MinValue (0)
+        ReadOnlySpan<byte> data5 = [0x00, 0x00];
+        var result5 = BitConverter.ToUInt16(data5);
+        Assert.Equal(ushort.MinValue, result5);
+    }
+
+    [Fact]
+    public void BitConverter_ToUInt32_ReadOnlySpan()
+    {
+        // Test with little-endian bytes representing 42
+        ReadOnlySpan<byte> data1 = [0x2A, 0x00, 0x00, 0x00];
+        var result1 = BitConverter.ToUInt32(data1);
+        Assert.Equal(42u, result1);
+
+        // Test with little-endian bytes representing 256
+        ReadOnlySpan<byte> data3 = [0x00, 0x01, 0x00, 0x00];
+        var result3 = BitConverter.ToUInt32(data3);
+        Assert.Equal(256u, result3);
+
+        // Test with little-endian bytes representing uint.MaxValue (4294967295)
+        ReadOnlySpan<byte> data4 = [0xFF, 0xFF, 0xFF, 0xFF];
+        var result4 = BitConverter.ToUInt32(data4);
+        Assert.Equal(uint.MaxValue, result4);
+
+        // Test with little-endian bytes representing uint.MinValue (0)
+        ReadOnlySpan<byte> data5 = [0x00, 0x00, 0x00, 0x00];
+        var result5 = BitConverter.ToUInt32(data5);
+        Assert.Equal(uint.MinValue, result5);
+    }
+
+    [Fact]
     public void String_Create()
     {
         var actual = string.Create(CultureInfo.InvariantCulture, $"a{1}b");

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.116</Version>
+    <Version>1.0.117</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (537)
+### Methods (539)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -143,6 +143,8 @@ The filtering logic works as follows:
 - `System.Array.Fill<T>(T[] array, T value, System.Int32 startIndex, System.Int32 count)`
 - `System.BitConverter.ToInt16(System.ReadOnlySpan<System.Byte> value)`
 - `System.BitConverter.ToInt32(System.ReadOnlySpan<System.Byte> value)`
+- `System.BitConverter.ToUInt16(System.ReadOnlySpan<System.Byte> value)`
+- `System.BitConverter.ToUInt32(System.ReadOnlySpan<System.Byte> value)`
 - `System.Byte.Parse(System.ReadOnlySpan<System.Byte> utf8Text, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
 - `System.Byte.Parse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider)`
 - `System.Byte.Parse(System.ReadOnlySpan<System.Char> s, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (539)
+### Methods (540)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`


### PR DESCRIPTION
## Why
`BitConverter.ToUInt16(ReadOnlySpan<Byte>)` and `BitConverter.ToUInt32(ReadOnlySpan<Byte>)` are available on newer TFMs but missing from the current polyfill surface. Adding them keeps `ReadOnlySpan<Byte>`-based BitConverter APIs consistent with the existing `ToInt16` and `ToInt32` polyfills.

## What changed
- Added new polyfills for:
  - `System.BitConverter.ToUInt16(ReadOnlySpan<Byte>)`
  - `System.BitConverter.ToUInt32(ReadOnlySpan<Byte>)`
- Implementation follows existing project patterns:
  - Delegates to the existing `BitConverter.ToUInt16(byte[], int)` / `BitConverter.ToUInt32(byte[], int)` array-based overload via `value.ToArray()`
- Added test coverage in SystemTests for:
  - Representative values (42, 256)
  - Boundary values (`ushort.MinValue`, `ushort.MaxValue`, `uint.MinValue`, `uint.MaxValue`)
- Regenerated metadata/docs outputs and bumped package version patch:
  - `polyfill-supported-versions.json`
  - `README.md`
  - `Meziantou.Polyfill.csproj` version 1.0.116 → 1.0.117

## Notes
This is intentionally a straightforward implementation matching the existing `BitConverter.ToInt16(ReadOnlySpan<Byte>)`  / `.BitConverter.ToInt32(ReadOnlySpan<Byte>)` polyfill style in this repository.
