### PR TITLE
Add List<T>.Slice polyfill

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.Collections.Generic.List`1.Slice(System.Int32,System.Int32).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Collections.Generic.List`1.Slice(System.Int32,System.Int32).cs
@@ -1,0 +1,6 @@
+using System.Collections.Generic;
+
+static partial class PolyfillExtensions
+{
+    public static List<T> Slice<T>(this List<T> list, int start, int length) => list.GetRange(start, length);
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -284,6 +284,11 @@
       "net9.0",
       "net10.0"
     ],
+    "M:System.Collections.Generic.List\u00601.Slice(System.Int32,System.Int32)": [
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
     "M:System.Collections.Generic.Queue\u00601.TryDequeue(\u00600@)": [
       "netstandard2.1",
       "net6.0",

--- a/Meziantou.Polyfill.Tests/SystemCollectionsGenericTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemCollectionsGenericTests.cs
@@ -344,5 +344,21 @@ public class SystemCollectionsGenericTests
         Assert.Equal("key", key);
         Assert.Null(value);
     }
+
+    [Fact]
+    public void List_Slice()
+    {
+        var list = new List<int> { 1, 2, 3, 4, 5 };
+        var result = list.Slice(1, 3);
+        Assert.Equal(new List<int> { 2, 3, 4 }, result);
+    }
+
+    [Fact]
+    public void List_Slice_EmptyRange()
+    {
+        var list = new List<int> { 1, 2, 3 };
+        var result = list.Slice(0, 0);
+        Assert.Empty(result);
+    }
 }
 

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.116</Version>
+    <Version>1.0.117</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (537)
+### Methods (538)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -166,6 +166,7 @@ The filtering logic works as follows:
 - `System.Collections.Generic.Dictionary<TKey, TValue>.Remove(TKey key, out TValue value)`
 - `System.Collections.Generic.Dictionary<TKey, TValue>.TryAdd(TKey key, TValue value)`
 - `System.Collections.Generic.KeyValuePair<TKey, TValue>.Deconstruct(out TKey key, out TValue value)`
+- `System.Collections.Generic.List<T>.Slice(System.Int32 start, System.Int32 length)`
 - `System.Collections.Generic.Queue<T>.TryDequeue(out T result)`
 - `System.Collections.Generic.SortedList<TKey, TValue>.GetKeyAtIndex(System.Int32 index)`
 - `System.Collections.Generic.SortedList<TKey, TValue>.GetValueAtIndex(System.Int32 index)`


### PR DESCRIPTION
## Why
`List<T>.Slice(int, int)` is available on newer TFMs but was missing from the polyfill surface. Adding it allows range-based slicing of lists to work consistently across all targeted frameworks.

## What changed
- Added a new polyfill in `PolyfillExtensions` for:
  - `System.Collections.Generic.List<T>.Slice(System.Int32 start, System.Int32 length)`
- Implementation delegates directly to the existing `List<T>.GetRange(int, int)` method:
  - `public static List<T> Slice<T>(this List<T> list, int start, int length) => list.GetRange(start, length);`
- Added test coverage in `SystemCollectionsGenericTests` for:
  - Mid-list slice returning the correct elements
  - Zero-length slice returning an empty list
- Regenerated metadata/docs outputs and bumped package version patch:
  - `Meziantou.Polyfill.csproj` version `1.0.116` -> `1.0.117`

## Notes
This is an intentionally minimal implementation — `GetRange` already handles all argument validation (`ArgumentOutOfRangeException` for out-of-bounds `start`/`length`) and returns a new `List<T>` shallow copy, matching the behaviour of the BCL method.