### PR TITLE
Align TimeSpan double operator polyfills with runtime behavior

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.TimeSpan.Multiply(System.Double).cs
+++ b/Meziantou.Polyfill.Editor/M;System.TimeSpan.Multiply(System.Double).cs
@@ -4,6 +4,26 @@ static partial class PolyfillExtensions
 {
     public static TimeSpan Multiply(this TimeSpan timeSpan, double factor)
     {
-        return new TimeSpan((long)(timeSpan.Ticks * factor));
+        if (double.IsNaN(factor))
+        {
+            throw new ArgumentException("TimeSpan does not accept floating point Not-a-Number values.", nameof(factor));
+        }
+
+        return IntervalFromDoubleTicks(timeSpan.Ticks * factor);
+
+        static TimeSpan IntervalFromDoubleTicks(double ticks)
+        {
+            if ((ticks > long.MaxValue) || (ticks < long.MinValue) || double.IsNaN(ticks))
+            {
+                throw new OverflowException();
+            }
+
+            if (ticks == long.MaxValue)
+            {
+                return TimeSpan.MaxValue;
+            }
+
+            return new TimeSpan((long)ticks);
+        }
     }
 }

--- a/Meziantou.Polyfill.Editor/M;System.TimeSpan.op_Division(System.TimeSpan,System.Double)~System.TimeSpan.cs
+++ b/Meziantou.Polyfill.Editor/M;System.TimeSpan.op_Division(System.TimeSpan,System.Double)~System.TimeSpan.cs
@@ -6,7 +6,27 @@ static partial class PolyfillExtensions
     {
         public static TimeSpan operator /(TimeSpan timeSpan, double divisor)
         {
-            return new TimeSpan((long)(timeSpan.Ticks / divisor));
+            if (double.IsNaN(divisor))
+            {
+                throw new ArgumentException("TimeSpan does not accept floating point Not-a-Number values.", nameof(divisor));
+            }
+
+            return IntervalFromDoubleTicks(timeSpan.Ticks / divisor);
+
+            static TimeSpan IntervalFromDoubleTicks(double ticks)
+            {
+                if ((ticks > long.MaxValue) || (ticks < long.MinValue) || double.IsNaN(ticks))
+                {
+                    throw new OverflowException();
+                }
+
+                if (ticks == long.MaxValue)
+                {
+                    return TimeSpan.MaxValue;
+                }
+
+                return new TimeSpan((long)ticks);
+            }
         }
     }
 }

--- a/Meziantou.Polyfill.Editor/M;System.TimeSpan.op_Multiply(System.Double,System.TimeSpan)~System.TimeSpan.cs
+++ b/Meziantou.Polyfill.Editor/M;System.TimeSpan.op_Multiply(System.Double,System.TimeSpan)~System.TimeSpan.cs
@@ -6,7 +6,27 @@ static partial class PolyfillExtensions
     {
         public static TimeSpan operator *(double factor, TimeSpan timeSpan)
         {
-            return new TimeSpan((long)(timeSpan.Ticks * factor));
+            if (double.IsNaN(factor))
+            {
+                throw new ArgumentException("TimeSpan does not accept floating point Not-a-Number values.", nameof(factor));
+            }
+
+            return IntervalFromDoubleTicks(timeSpan.Ticks * factor);
+
+            static TimeSpan IntervalFromDoubleTicks(double ticks)
+            {
+                if ((ticks > long.MaxValue) || (ticks < long.MinValue) || double.IsNaN(ticks))
+                {
+                    throw new OverflowException();
+                }
+
+                if (ticks == long.MaxValue)
+                {
+                    return TimeSpan.MaxValue;
+                }
+
+                return new TimeSpan((long)ticks);
+            }
         }
     }
 }

--- a/Meziantou.Polyfill.Editor/M;System.TimeSpan.op_Multiply(System.TimeSpan,System.Double)~System.TimeSpan.cs
+++ b/Meziantou.Polyfill.Editor/M;System.TimeSpan.op_Multiply(System.TimeSpan,System.Double)~System.TimeSpan.cs
@@ -6,7 +6,27 @@ static partial class PolyfillExtensions
     {
         public static TimeSpan operator *(TimeSpan timeSpan, double factor)
         {
-            return new TimeSpan((long)(timeSpan.Ticks * factor));
+            if (double.IsNaN(factor))
+            {
+                throw new ArgumentException("TimeSpan does not accept floating point Not-a-Number values.", nameof(factor));
+            }
+
+            return IntervalFromDoubleTicks(timeSpan.Ticks * factor);
+
+            static TimeSpan IntervalFromDoubleTicks(double ticks)
+            {
+                if ((ticks > long.MaxValue) || (ticks < long.MinValue) || double.IsNaN(ticks))
+                {
+                    throw new OverflowException();
+                }
+
+                if (ticks == long.MaxValue)
+                {
+                    return TimeSpan.MaxValue;
+                }
+
+                return new TimeSpan((long)ticks);
+            }
         }
     }
 }

--- a/Meziantou.Polyfill.Tests/SystemTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemTests.cs
@@ -288,6 +288,14 @@ public class SystemTests
     }
 
     [Fact]
+    public void TimeSpan_Multiply_Double_TimeSpan_EdgeCases()
+    {
+        Assert.Equal(TimeSpan.MaxValue, 1.0 * TimeSpan.MaxValue);
+        Assert.Throws<ArgumentException>(() => double.NaN * TimeSpan.FromSeconds(1));
+        Assert.Throws<OverflowException>(() => 2.0 * TimeSpan.MaxValue);
+    }
+
+    [Fact]
     public void TimeSpan_Multiply_TimeSpan_Double()
     {
         // Test basic multiplication: 1 second * 2.0 = 2 seconds
@@ -304,6 +312,22 @@ public class SystemTests
     }
 
     [Fact]
+    public void TimeSpan_Multiply_TimeSpan_Double_EdgeCases()
+    {
+        Assert.Equal(TimeSpan.MaxValue, TimeSpan.MaxValue * 1.0);
+        Assert.Throws<ArgumentException>(() => TimeSpan.FromSeconds(1) * double.NaN);
+        Assert.Throws<OverflowException>(() => TimeSpan.MaxValue * 2.0);
+    }
+
+    [Fact]
+    public void TimeSpan_Multiply_Method_EdgeCases()
+    {
+        Assert.Equal(TimeSpan.MaxValue, TimeSpan.MaxValue.Multiply(1.0));
+        Assert.Throws<ArgumentException>(() => TimeSpan.FromSeconds(1).Multiply(double.NaN));
+        Assert.Throws<OverflowException>(() => TimeSpan.MaxValue.Multiply(2.0));
+    }
+
+    [Fact]
     public void TimeSpan_Division_Double()
     {
         // Test basic division: 10 seconds / 2.0 = 5 seconds
@@ -317,6 +341,15 @@ public class SystemTests
 
         // Test large values: 1 hour / 60 = 1 minute
         Assert.Equal(TimeSpan.FromMinutes(1), TimeSpan.FromHours(1) / 60.0);
+    }
+
+    [Fact]
+    public void TimeSpan_Division_Double_EdgeCases()
+    {
+        Assert.Equal(TimeSpan.MaxValue, TimeSpan.MaxValue / 1.0);
+        Assert.Throws<OverflowException>(() => TimeSpan.FromSeconds(1) / 0.0);
+        Assert.Throws<OverflowException>(() => TimeSpan.Zero / 0.0);
+        Assert.Throws<ArgumentException>(() => TimeSpan.FromSeconds(1) / double.NaN);
     }
 
     [Fact]


### PR DESCRIPTION
## Why
The `TimeSpan` double operator polyfills (`*` and `/`) used direct `double -> long` casts, which did not match runtime behavior for edge cases such as `NaN` and overflow-style inputs.

## What changed
- Updated `TimeSpan * double`, `double * TimeSpan`, and `TimeSpan / double` polyfills to align with runtime semantics:
  - throw `ArgumentException` for `NaN` factor/divisor
  - throw `OverflowException` when computed ticks are out of range or otherwise invalid for `TimeSpan`
  - preserve the `TimeSpan.MaxValue` boundary case
- Kept `TimeSpan.Multiply(double)` behavior consistent with the operator changes.
- Added edge-case tests in `SystemTests` for:
  - `NaN` inputs
  - overflow scenarios
  - zero-divisor behavior
  - max-value boundary handling

## Notes for reviewers
The behavioral change is intentional and focused on runtime parity for the double-based TimeSpan operations.

## Validation
- `dotnet run --project ./Meziantou.Polyfill.Generator/Meziantou.Polyfill.Generator.csproj`
- `dotnet build`
- `dotnet test ./Meziantou.Polyfill.Tests/Meziantou.Polyfill.Tests.csproj -f net10.0`
- `dotnet test ./Meziantou.Polyfill.SourceGenerator.Tests/Meziantou.Polyfill.SourceGenerator.Tests.csproj -f net10.0`

Full multi-target `dotnet test` in this environment aborts for .NET Framework targets (`net462/net472/net48/net481`) because `mono` is not available.