### PR TITLE
Reduce DateTimeOffset.UnixEpoch allocations

### DIFF
--- a/Meziantou.Polyfill.Editor/F;System.DateTimeOffset.UnixEpoch.cs
+++ b/Meziantou.Polyfill.Editor/F;System.DateTimeOffset.UnixEpoch.cs
@@ -1,8 +1,15 @@
+using System;
+
 static partial class PolyfillExtensions
 {
-    extension(System.DateTimeOffset)
+    extension(DateTimeOffset)
     {
-        // 621355968000000000L = ticks for January 1, 1970, 00:00:00 UTC
-        public static System.DateTimeOffset UnixEpoch => new System.DateTimeOffset(621355968000000000L, System.TimeSpan.Zero);
+        public static DateTimeOffset UnixEpoch => DateTimeOffsetHelpers.UnixEpoch;
     }
+}
+
+file static class DateTimeOffsetHelpers
+{
+    // 621355968000000000L = ticks for January 1, 1970, 00:00:00 UTC
+    public static readonly DateTimeOffset UnixEpoch = new DateTimeOffset(621355968000000000L, TimeSpan.Zero);
 }

--- a/Meziantou.Polyfill.Editor/T;System.Reflection.NullabilityInfo.cs
+++ b/Meziantou.Polyfill.Editor/T;System.Reflection.NullabilityInfo.cs
@@ -1,0 +1,40 @@
+﻿namespace System.Reflection
+{
+    /// <summary>
+    /// A class that represents nullability info
+    /// </summary>
+    internal sealed class NullabilityInfo
+    {
+        internal NullabilityInfo(Type type, NullabilityState readState, NullabilityState writeState,
+            NullabilityInfo? elementType, NullabilityInfo[] typeArguments)
+        {
+            Type = type;
+            ReadState = readState;
+            WriteState = writeState;
+            ElementType = elementType;
+            GenericTypeArguments = typeArguments;
+        }
+
+        /// <summary>
+        /// The <see cref="System.Type" /> of the member or generic parameter
+        /// to which this NullabilityInfo belongs
+        /// </summary>
+        public Type Type { get; }
+        /// <summary>
+        /// The nullability read state of the member
+        /// </summary>
+        public NullabilityState ReadState { get; internal set; }
+        /// <summary>
+        /// The nullability write state of the member
+        /// </summary>
+        public NullabilityState WriteState { get; internal set; }
+        /// <summary>
+        /// If the member type is an array, gives the <see cref="NullabilityInfo" /> of the elements of the array, null otherwise
+        /// </summary>
+        public NullabilityInfo? ElementType { get; }
+        /// <summary>
+        /// If the member type is a generic type, gives the array of <see cref="NullabilityInfo" /> for each type parameter
+        /// </summary>
+        public NullabilityInfo[] GenericTypeArguments { get; }
+    }
+}

--- a/Meziantou.Polyfill.Editor/T;System.Reflection.NullabilityState.cs
+++ b/Meziantou.Polyfill.Editor/T;System.Reflection.NullabilityState.cs
@@ -1,0 +1,22 @@
+﻿// when T:System.Reflection.NullabilityInfo
+namespace System.Reflection
+{
+    /// <summary>
+    /// An enum that represents nullability state
+    /// </summary>
+    internal enum NullabilityState
+    {
+        /// <summary>
+        /// Nullability context not enabled (oblivious)
+        /// </summary>
+        Unknown,
+        /// <summary>
+        /// Non nullable value or reference type
+        /// </summary>
+        NotNull,
+        /// <summary>
+        /// Nullable value or reference type
+        /// </summary>
+        Nullable
+    }
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -3416,6 +3416,20 @@
       "net9.0",
       "net10.0"
     ],
+    "T:System.Reflection.NullabilityInfo": [
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
+    "T:System.Reflection.NullabilityState": [
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
     "T:System.Runtime.CompilerServices.AsyncMethodBuilderAttribute": [
       "netstandard2.1",
       "net6.0",

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The filtering logic works as follows:
 
 <!-- begin_polyfills -->
 
-### Types (71)
+### Types (73)
 
 - `System.Buffers.SearchValues`
 - `System.Buffers.SearchValues<T> where T : System.IEquatable<T>?`
@@ -89,6 +89,8 @@ The filtering logic works as follows:
 - `System.Index`
 - `System.Net.Http.ReadOnlyMemoryContent`
 - `System.Range`
+- `System.Reflection.NullabilityInfo`
+- `System.Reflection.NullabilityState`
 - `System.Runtime.CompilerServices.AsyncMethodBuilderAttribute`
 - `System.Runtime.CompilerServices.CallerArgumentExpressionAttribute`
 - `System.Runtime.CompilerServices.CollectionBuilderAttribute`


### PR DESCRIPTION
# Why

`System.DateTimeOffset.UnixEpoch` would allocate a new value on the stack every time it was referenced. Using a `static` value reduces the possible allocations in hot paths using this field.

# What changed

- Added `file` scoped class with `static readonly` field to hold a single `System.DateTimeOffset` value for use with the extension.