### PR TITLE
Reduce System.DateTimeOffset.UnixEpoch allocations

### DIFF
--- a/Meziantou.Polyfill.Editor/F;System.DateTimeOffset.UnixEpoch.cs
+++ b/Meziantou.Polyfill.Editor/F;System.DateTimeOffset.UnixEpoch.cs
@@ -1,8 +1,15 @@
+using System;
+
 static partial class PolyfillExtensions
 {
-    extension(System.DateTimeOffset)
+    extension(DateTimeOffset)
     {
-        // 621355968000000000L = ticks for January 1, 1970, 00:00:00 UTC
-        public static System.DateTimeOffset UnixEpoch => new System.DateTimeOffset(621355968000000000L, System.TimeSpan.Zero);
+        public static DateTimeOffset UnixEpoch => DateTimeOffsetHelpers.UnixEpoch;
     }
+}
+
+file static class DateTimeOffsetHelpers
+{
+    // 621355968000000000L = ticks for January 1, 1970, 00:00:00 UTC
+    public static readonly DateTimeOffset UnixEpoch = new DateTimeOffset(621355968000000000L, TimeSpan.Zero);
 }


### PR DESCRIPTION
# Why

`System.DateTimeOffset.UnixEpoch` would allocate a new value on the stack every time it was referenced. Using a `static` value reduces the possible allocations in hot paths using this field.

# What changed

- Added `file` scoped class with `static readonly` field to hold a single `System.DateTimeOffset` value for use with the extension.