### PR TITLE
Add StringComparer.FromComparison(StringComparison) polyfill

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.StringComparer.FromComparison(System.StringComparison).cs
+++ b/Meziantou.Polyfill.Editor/M;System.StringComparer.FromComparison(System.StringComparison).cs
@@ -1,0 +1,33 @@
+using System;
+
+static partial class PolyfillExtensions
+{
+    extension(StringComparer)
+    {
+        /// <summary>
+        /// Converts the specified <see cref="StringComparison"/> to a <see cref="StringComparer"/> instance.
+        /// </summary>
+        /// <param name="comparisonType">
+        /// A string comparer instance to convert.
+        /// </param>
+        /// <returns>
+        /// A <see cref="StringComparer"/> instance representing the equivalent value of the specified <see cref="StringComparison"/> instance.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the specified <see cref="StringComparison"/> value is not supported.
+        /// </exception>
+        public static StringComparer FromComparison(StringComparison comparisonType)
+        {
+            return comparisonType switch
+            {
+                StringComparison.CurrentCulture => StringComparer.CurrentCulture,
+                StringComparison.CurrentCultureIgnoreCase => StringComparer.CurrentCultureIgnoreCase,
+                StringComparison.InvariantCulture => StringComparer.InvariantCulture,
+                StringComparison.InvariantCultureIgnoreCase => StringComparer.InvariantCultureIgnoreCase,
+                StringComparison.Ordinal => StringComparer.Ordinal,
+                StringComparison.OrdinalIgnoreCase => StringComparer.OrdinalIgnoreCase,
+                _ => throw new ArgumentException("The string comparison type passed in is currently not supported.", nameof(comparisonType)),
+            };
+        }
+    }
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -2519,6 +2519,14 @@
       "net9.0",
       "net10.0"
     ],
+    "M:System.StringComparer.FromComparison(System.StringComparison)": [
+      "netstandard2.1",
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
     "M:System.Text.Encoding.GetByteCount(System.ReadOnlySpan{System.Char})": [
       "netstandard2.1",
       "net6.0",

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (545)
+### Methods (546)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -588,6 +588,7 @@ The filtering logic works as follows:
 - `System.String.Split(System.Char separator, [System.StringSplitOptions options = System.StringSplitOptions.None])`
 - `System.String.StartsWith(System.Char value)`
 - `System.String.TryCopyTo(System.Span<System.Char> destination)`
+- `System.StringComparer.FromComparison(System.StringComparison comparisonType)`
 - `System.Text.Encoding.GetByteCount(System.ReadOnlySpan<System.Char> chars)`
 - `System.Text.Encoding.GetBytes(System.ReadOnlySpan<System.Char> chars, System.Span<System.Byte> bytes)`
 - `System.Text.Encoding.GetCharCount(System.ReadOnlySpan<System.Byte> bytes)`


### PR DESCRIPTION
# Why

`StringComparer.FromComparison(StringComparison)` is a very handy utility method.

# What changed

- Added polyfill for `StringComparer.FromComparison(StringComparison)`, based directly on [dotnet/runtime](https://github.com/dotnet/runtime/blob/fc46e69833252336a0ac9e147631952d64e04305/src/libraries/System.Private.CoreLib/src/System/StringComparer.cs#L32) source.