### PR TITLE
Add System.Reflection.NullabilityInfo* polyfills

### DIFF
--- a/Meziantou.Polyfill.Editor/T;System.Reflection.NullabilityInfo.cs
+++ b/Meziantou.Polyfill.Editor/T;System.Reflection.NullabilityInfo.cs
@@ -1,0 +1,41 @@
+﻿// when T:System.Reflection.NullabilityInfoContext
+namespace System.Reflection
+{
+    /// <summary>
+    /// A class that represents nullability info
+    /// </summary>
+    internal sealed class NullabilityInfo
+    {
+        internal NullabilityInfo(Type type, NullabilityState readState, NullabilityState writeState,
+            NullabilityInfo? elementType, NullabilityInfo[] typeArguments)
+        {
+            Type = type;
+            ReadState = readState;
+            WriteState = writeState;
+            ElementType = elementType;
+            GenericTypeArguments = typeArguments;
+        }
+
+        /// <summary>
+        /// The <see cref="System.Type" /> of the member or generic parameter
+        /// to which this NullabilityInfo belongs
+        /// </summary>
+        public Type Type { get; }
+        /// <summary>
+        /// The nullability read state of the member
+        /// </summary>
+        public NullabilityState ReadState { get; internal set; }
+        /// <summary>
+        /// The nullability write state of the member
+        /// </summary>
+        public NullabilityState WriteState { get; internal set; }
+        /// <summary>
+        /// If the member type is an array, gives the <see cref="NullabilityInfo" /> of the elements of the array, null otherwise
+        /// </summary>
+        public NullabilityInfo? ElementType { get; }
+        /// <summary>
+        /// If the member type is a generic type, gives the array of <see cref="NullabilityInfo" /> for each type parameter
+        /// </summary>
+        public NullabilityInfo[] GenericTypeArguments { get; }
+    }
+}

--- a/Meziantou.Polyfill.Editor/T;System.Reflection.NullabilityInfoContext.cs
+++ b/Meziantou.Polyfill.Editor/T;System.Reflection.NullabilityInfoContext.cs
@@ -1,0 +1,704 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+
+namespace System.Reflection
+{
+    /// <summary>
+    /// Provides APIs for populating nullability information/context from reflection members:
+    /// <see cref="ParameterInfo"/>, <see cref="FieldInfo"/>, <see cref="PropertyInfo"/> and <see cref="EventInfo"/>.
+    /// </summary>
+    internal sealed class NullabilityInfoContext
+    {
+        private const string CompilerServicesNameSpace = "System.Runtime.CompilerServices";
+        private readonly Dictionary<Module, NotAnnotatedStatus> _publicOnlyModules = new();
+        private readonly Dictionary<MemberInfo, NullabilityState> _context = new();
+
+        [Flags]
+        private enum NotAnnotatedStatus
+        {
+            None = 0x0,    // no restriction, all members annotated
+            Private = 0x1, // private members not annotated
+            Internal = 0x2 // internal members not annotated
+        }
+
+        private NullabilityState? GetNullableContext(MemberInfo? memberInfo)
+        {
+            while (memberInfo != null)
+            {
+                if (_context.TryGetValue(memberInfo, out NullabilityState state))
+                {
+                    return state;
+                }
+
+                foreach (CustomAttributeData attribute in memberInfo.GetCustomAttributesData())
+                {
+                    if (attribute.AttributeType.Name == "NullableContextAttribute" &&
+                        attribute.AttributeType.Namespace == CompilerServicesNameSpace &&
+                        attribute.ConstructorArguments.Count == 1)
+                    {
+                        state = TranslateByte(attribute.ConstructorArguments[0].Value);
+                        _context.Add(memberInfo, state);
+                        return state;
+                    }
+                }
+
+                memberInfo = memberInfo.DeclaringType;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="ParameterInfo" />.
+        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+        /// </summary>
+        /// <param name="parameterInfo">The parameter which nullability info gets populated</param>
+        /// <exception cref="ArgumentNullException">If the parameterInfo parameter is null</exception>
+        /// <returns><see cref="NullabilityInfo" /></returns>
+        public NullabilityInfo Create(ParameterInfo parameterInfo)
+        {
+            ArgumentNullException.ThrowIfNull(parameterInfo);
+
+            IList<CustomAttributeData> attributes = parameterInfo.GetCustomAttributesData();
+            NullableAttributeStateParser parser = parameterInfo.Member is MethodBase method && IsPrivateOrInternalMethodAndAnnotationDisabled(method)
+                ? NullableAttributeStateParser.Unknown
+                : CreateParser(attributes);
+            NullabilityInfo nullability = GetNullabilityInfo(parameterInfo.Member, parameterInfo.ParameterType, parser);
+
+            if (nullability.ReadState != NullabilityState.Unknown)
+            {
+                CheckParameterMetadataType(parameterInfo, nullability);
+            }
+
+            CheckNullabilityAttributes(nullability, attributes);
+            return nullability;
+        }
+
+        private void CheckParameterMetadataType(ParameterInfo parameter, NullabilityInfo nullability)
+        {
+            ParameterInfo? metaParameter;
+            MemberInfo metaMember;
+
+            switch (parameter.Member)
+            {
+                case ConstructorInfo ctor:
+                    var metaCtor = (ConstructorInfo)GetMemberMetadataDefinition(ctor);
+                    metaMember = metaCtor;
+                    metaParameter = GetMetaParameter(metaCtor, parameter);
+                    break;
+
+                case MethodInfo method:
+                    MethodInfo metaMethod = GetMethodMetadataDefinition(method);
+                    metaMember = metaMethod;
+                    metaParameter = string.IsNullOrEmpty(parameter.Name) ? metaMethod.ReturnParameter : GetMetaParameter(metaMethod, parameter);
+                    break;
+
+                default:
+                    return;
+            }
+
+            if (metaParameter != null)
+            {
+                CheckGenericParameters(nullability, metaMember, metaParameter.ParameterType, parameter.Member.ReflectedType);
+            }
+        }
+
+        private static ParameterInfo? GetMetaParameter(MethodBase metaMethod, ParameterInfo parameter)
+        {
+            ReadOnlySpan<ParameterInfo> parameters = metaMethod.GetParametersAsSpan();
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                if (parameter.Position == i &&
+                    parameter.Name == parameters[i].Name)
+                {
+                    return parameters[i];
+                }
+            }
+
+            return null;
+        }
+        private static MethodInfo GetMethodMetadataDefinition(MethodInfo method)
+        {
+            if (method.IsGenericMethod && !method.IsGenericMethodDefinition)
+            {
+                method = method.GetGenericMethodDefinition();
+            }
+
+            return (MethodInfo)GetMemberMetadataDefinition(method);
+        }
+
+        private static void CheckNullabilityAttributes(NullabilityInfo nullability, IList<CustomAttributeData> attributes)
+        {
+            var codeAnalysisReadState = NullabilityState.Unknown;
+            var codeAnalysisWriteState = NullabilityState.Unknown;
+
+            foreach (CustomAttributeData attribute in attributes)
+            {
+                if (attribute.AttributeType.Namespace == "System.Diagnostics.CodeAnalysis")
+                {
+                    if (attribute.AttributeType.Name == "NotNullAttribute")
+                    {
+                        codeAnalysisReadState = NullabilityState.NotNull;
+                    }
+                    else if ((attribute.AttributeType.Name == "MaybeNullAttribute" ||
+                            attribute.AttributeType.Name == "MaybeNullWhenAttribute") &&
+                            codeAnalysisReadState == NullabilityState.Unknown &&
+                            !IsValueTypeOrValueTypeByRef(nullability.Type))
+                    {
+                        codeAnalysisReadState = NullabilityState.Nullable;
+                    }
+                    else if (attribute.AttributeType.Name == "DisallowNullAttribute")
+                    {
+                        codeAnalysisWriteState = NullabilityState.NotNull;
+                    }
+                    else if (attribute.AttributeType.Name == "AllowNullAttribute" &&
+                        codeAnalysisWriteState == NullabilityState.Unknown &&
+                        !IsValueTypeOrValueTypeByRef(nullability.Type))
+                    {
+                        codeAnalysisWriteState = NullabilityState.Nullable;
+                    }
+                }
+            }
+
+            if (codeAnalysisReadState != NullabilityState.Unknown)
+            {
+                nullability.ReadState = codeAnalysisReadState;
+            }
+            if (codeAnalysisWriteState != NullabilityState.Unknown)
+            {
+                nullability.WriteState = codeAnalysisWriteState;
+            }
+        }
+
+        /// <summary>
+        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="PropertyInfo" />.
+        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+        /// </summary>
+        /// <param name="propertyInfo">The parameter which nullability info gets populated</param>
+        /// <exception cref="ArgumentNullException">If the propertyInfo parameter is null</exception>
+        /// <returns><see cref="NullabilityInfo" /></returns>
+        public NullabilityInfo Create(PropertyInfo propertyInfo)
+        {
+            ArgumentNullException.ThrowIfNull(propertyInfo);
+
+            MethodInfo? getter = propertyInfo.GetGetMethod(true);
+            MethodInfo? setter = propertyInfo.GetSetMethod(true);
+            bool annotationsDisabled = (getter == null || IsPrivateOrInternalMethodAndAnnotationDisabled(getter))
+                && (setter == null || IsPrivateOrInternalMethodAndAnnotationDisabled(setter));
+            NullableAttributeStateParser parser = annotationsDisabled ? NullableAttributeStateParser.Unknown : CreateParser(propertyInfo.GetCustomAttributesData());
+            NullabilityInfo nullability = GetNullabilityInfo(propertyInfo, propertyInfo.PropertyType, parser);
+
+            if (getter != null)
+            {
+                CheckNullabilityAttributes(nullability, getter.ReturnParameter.GetCustomAttributesData());
+            }
+            else
+            {
+                nullability.ReadState = NullabilityState.Unknown;
+            }
+
+            if (setter != null)
+            {
+                ReadOnlySpan<ParameterInfo> parameters = setter.GetParametersAsSpan();
+                ParameterInfo parameter = parameters[parameters.Length - 1];
+                CheckNullabilityAttributes(nullability, parameter.GetCustomAttributesData());
+            }
+            else
+            {
+                nullability.WriteState = NullabilityState.Unknown;
+            }
+
+            return nullability;
+        }
+
+        private bool IsPrivateOrInternalMethodAndAnnotationDisabled(MethodBase method)
+        {
+            if ((method.IsPrivate || method.IsFamilyAndAssembly || method.IsAssembly) &&
+               IsPublicOnly(method.IsPrivate, method.IsFamilyAndAssembly, method.IsAssembly, method.Module))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="EventInfo" />.
+        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+        /// </summary>
+        /// <param name="eventInfo">The parameter which nullability info gets populated</param>
+        /// <exception cref="ArgumentNullException">If the eventInfo parameter is null</exception>
+        /// <returns><see cref="NullabilityInfo" /></returns>
+        public NullabilityInfo Create(EventInfo eventInfo)
+        {
+            ArgumentNullException.ThrowIfNull(eventInfo);
+
+            return GetNullabilityInfo(eventInfo, eventInfo.EventHandlerType!, CreateParser(eventInfo.GetCustomAttributesData()));
+        }
+
+        /// <summary>
+        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="FieldInfo" />
+        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+        /// </summary>
+        /// <param name="fieldInfo">The parameter which nullability info gets populated</param>
+        /// <exception cref="ArgumentNullException">If the fieldInfo parameter is null</exception>
+        /// <returns><see cref="NullabilityInfo" /></returns>
+        public NullabilityInfo Create(FieldInfo fieldInfo)
+        {
+            ArgumentNullException.ThrowIfNull(fieldInfo);
+
+            IList<CustomAttributeData> attributes = fieldInfo.GetCustomAttributesData();
+            NullableAttributeStateParser parser = IsPrivateOrInternalFieldAndAnnotationDisabled(fieldInfo) ? NullableAttributeStateParser.Unknown : CreateParser(attributes);
+            NullabilityInfo nullability = GetNullabilityInfo(fieldInfo, fieldInfo.FieldType, parser);
+            CheckNullabilityAttributes(nullability, attributes);
+            return nullability;
+        }
+
+        private bool IsPrivateOrInternalFieldAndAnnotationDisabled(FieldInfo fieldInfo)
+        {
+            if ((fieldInfo.IsPrivate || fieldInfo.IsFamilyAndAssembly || fieldInfo.IsAssembly) &&
+                IsPublicOnly(fieldInfo.IsPrivate, fieldInfo.IsFamilyAndAssembly, fieldInfo.IsAssembly, fieldInfo.Module))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool IsPublicOnly(bool isPrivate, bool isFamilyAndAssembly, bool isAssembly, Module module)
+        {
+            if (!_publicOnlyModules.TryGetValue(module, out NotAnnotatedStatus value))
+            {
+                value = PopulateAnnotationInfo(module.GetCustomAttributesData());
+                _publicOnlyModules.Add(module, value);
+            }
+
+            if (value == NotAnnotatedStatus.None)
+            {
+                return false;
+            }
+
+            if ((isPrivate || isFamilyAndAssembly) && value.HasFlag(NotAnnotatedStatus.Private) ||
+                 isAssembly && value.HasFlag(NotAnnotatedStatus.Internal))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static NotAnnotatedStatus PopulateAnnotationInfo(IList<CustomAttributeData> customAttributes)
+        {
+            foreach (CustomAttributeData attribute in customAttributes)
+            {
+                if (attribute.AttributeType.Name == "NullablePublicOnlyAttribute" &&
+                    attribute.AttributeType.Namespace == CompilerServicesNameSpace &&
+                    attribute.ConstructorArguments.Count == 1)
+                {
+                    if (attribute.ConstructorArguments[0].Value is bool boolValue && boolValue)
+                    {
+                        return NotAnnotatedStatus.Internal | NotAnnotatedStatus.Private;
+                    }
+                    else
+                    {
+                        return NotAnnotatedStatus.Private;
+                    }
+                }
+            }
+
+            return NotAnnotatedStatus.None;
+        }
+
+        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, NullableAttributeStateParser parser)
+        {
+            int index = 0;
+            NullabilityInfo nullability = GetNullabilityInfo(memberInfo, type, parser, ref index);
+
+            if (nullability.ReadState != NullabilityState.Unknown)
+            {
+                TryLoadGenericMetaTypeNullability(memberInfo, nullability);
+            }
+
+            return nullability;
+        }
+
+        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, NullableAttributeStateParser parser, ref int index)
+        {
+            NullabilityState state = NullabilityState.Unknown;
+            NullabilityInfo? elementState = null;
+            NullabilityInfo[] genericArgumentsState = [];
+            Type underlyingType = type;
+
+            if (underlyingType.IsByRef || underlyingType.IsPointer)
+            {
+                underlyingType = underlyingType.GetElementType()!;
+            }
+
+            if (underlyingType.IsValueType)
+            {
+                if (Nullable.GetUnderlyingType(underlyingType) is { } nullableUnderlyingType)
+                {
+                    underlyingType = nullableUnderlyingType;
+                    state = NullabilityState.Nullable;
+                }
+                else
+                {
+                    state = NullabilityState.NotNull;
+                }
+
+                if (underlyingType.IsGenericType)
+                {
+                    ++index;
+                }
+            }
+            else
+            {
+                if (!parser.ParseNullableState(index++, ref state)
+                    && GetNullableContext(memberInfo) is { } contextState)
+                {
+                    state = contextState;
+                }
+
+                if (underlyingType.IsArray)
+                {
+                    elementState = GetNullabilityInfo(memberInfo, underlyingType.GetElementType()!, parser, ref index);
+                }
+            }
+
+            if (underlyingType.IsGenericType)
+            {
+                Type[] genericArguments = underlyingType.GetGenericArguments();
+                genericArgumentsState = new NullabilityInfo[genericArguments.Length];
+
+                for (int i = 0; i < genericArguments.Length; i++)
+                {
+                    genericArgumentsState[i] = GetNullabilityInfo(memberInfo, genericArguments[i], parser, ref index);
+                }
+            }
+
+            return new NullabilityInfo(type, state, state, elementState, genericArgumentsState);
+        }
+
+        private static NullableAttributeStateParser CreateParser(IList<CustomAttributeData> customAttributes)
+        {
+            foreach (CustomAttributeData attribute in customAttributes)
+            {
+                if (attribute.AttributeType.Name == "NullableAttribute" &&
+                    attribute.AttributeType.Namespace == CompilerServicesNameSpace &&
+                    attribute.ConstructorArguments.Count == 1)
+                {
+                    return new NullableAttributeStateParser(attribute.ConstructorArguments[0].Value);
+                }
+            }
+
+            return new NullableAttributeStateParser(null);
+        }
+
+        private void TryLoadGenericMetaTypeNullability(MemberInfo memberInfo, NullabilityInfo nullability)
+        {
+            MemberInfo? metaMember = GetMemberMetadataDefinition(memberInfo);
+            Type? metaType = null;
+            if (metaMember is FieldInfo field)
+            {
+                metaType = field.FieldType;
+            }
+            else if (metaMember is PropertyInfo property)
+            {
+                metaType = GetPropertyMetaType(property);
+            }
+
+            if (metaType != null)
+            {
+                CheckGenericParameters(nullability, metaMember, metaType, memberInfo.ReflectedType);
+            }
+        }
+
+        private static MemberInfo GetMemberMetadataDefinition(MemberInfo member)
+        {
+            Type? type = member.DeclaringType;
+            if ((type != null) && type.IsGenericType && !type.IsGenericTypeDefinition)
+            {
+                return type.GetGenericTypeDefinition().GetMemberWithSameMetadataDefinitionAs(member);
+            }
+
+            return member;
+        }
+
+        private static Type GetPropertyMetaType(PropertyInfo property)
+        {
+            if (property.GetGetMethod(true) is MethodInfo method)
+            {
+                return method.ReturnType;
+            }
+
+            return property.GetSetMethod(true)!.GetParametersAsSpan()[0].ParameterType;
+        }
+
+        private void CheckGenericParameters(NullabilityInfo nullability, MemberInfo metaMember, Type metaType, Type? reflectedType)
+        {
+            if (metaType.IsGenericParameter)
+            {
+                if (nullability.ReadState == NullabilityState.NotNull)
+                {
+                    TryUpdateGenericParameterNullability(nullability, metaType, reflectedType);
+                }
+            }
+            else if (metaType.ContainsGenericParameters)
+            {
+                if (nullability.GenericTypeArguments.Length > 0)
+                {
+                    Type[] genericArguments = metaType.GetGenericArguments();
+
+                    for (int i = 0; i < genericArguments.Length; i++)
+                    {
+                        CheckGenericParameters(nullability.GenericTypeArguments[i], metaMember, genericArguments[i], reflectedType);
+                    }
+                }
+                else if (nullability.ElementType is { } elementNullability && metaType.IsArray)
+                {
+                    CheckGenericParameters(elementNullability, metaMember, metaType.GetElementType()!, reflectedType);
+                }
+                // We could also follow this branch for metaType.IsPointer, but since pointers must be unmanaged this
+                // will be a no-op regardless
+                else if (metaType.IsByRef)
+                {
+                    CheckGenericParameters(nullability, metaMember, metaType.GetElementType()!, reflectedType);
+                }
+            }
+        }
+
+        private bool TryUpdateGenericParameterNullability(NullabilityInfo nullability, Type genericParameter, Type? reflectedType)
+        {
+            Debug.Assert(genericParameter.IsGenericParameter);
+
+            if (reflectedType is not null
+#if NET
+                && !genericParameter.IsGenericMethodParameter
+#else
+                && !genericParameter.IsGenericMethodParameter()
+#endif
+                && TryUpdateGenericTypeParameterNullabilityFromReflectedType(nullability, genericParameter, reflectedType, reflectedType))
+            {
+                return true;
+            }
+
+            if (IsValueTypeOrValueTypeByRef(nullability.Type))
+            {
+                return true;
+            }
+
+            var state = NullabilityState.Unknown;
+            if (CreateParser(genericParameter.GetCustomAttributesData()).ParseNullableState(0, ref state))
+            {
+                nullability.ReadState = state;
+                nullability.WriteState = state;
+                return true;
+            }
+
+            if (GetNullableContext(genericParameter) is { } contextState)
+            {
+                nullability.ReadState = contextState;
+                nullability.WriteState = contextState;
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool TryUpdateGenericTypeParameterNullabilityFromReflectedType(NullabilityInfo nullability, Type genericParameter, Type context, Type reflectedType)
+        {
+            Debug.Assert(genericParameter.IsGenericParameter &&
+#if NET
+                !genericParameter.IsGenericMethodParameter);
+#else
+                !genericParameter.IsGenericMethodParameter());
+#endif
+
+            Type contextTypeDefinition = context.IsGenericType && !context.IsGenericTypeDefinition ? context.GetGenericTypeDefinition() : context;
+            if (genericParameter.DeclaringType == contextTypeDefinition)
+            {
+                return false;
+            }
+
+            Type? baseType = contextTypeDefinition.BaseType;
+            if (baseType is null)
+            {
+                return false;
+            }
+
+            if (!baseType.IsGenericType
+                || (baseType.IsGenericTypeDefinition ? baseType : baseType.GetGenericTypeDefinition()) != genericParameter.DeclaringType)
+            {
+                return TryUpdateGenericTypeParameterNullabilityFromReflectedType(nullability, genericParameter, baseType, reflectedType);
+            }
+
+            Type[] genericArguments = baseType.GetGenericArguments();
+            Type genericArgument = genericArguments[genericParameter.GenericParameterPosition];
+            if (genericArgument.IsGenericParameter)
+            {
+                return TryUpdateGenericParameterNullability(nullability, genericArgument, reflectedType);
+            }
+
+            NullableAttributeStateParser parser = CreateParser(contextTypeDefinition.GetCustomAttributesData());
+            int nullabilityStateIndex = 1; // start at 1 since index 0 is the type itself
+            for (int i = 0; i < genericParameter.GenericParameterPosition; i++)
+            {
+                nullabilityStateIndex += CountNullabilityStates(genericArguments[i]);
+            }
+            return TryPopulateNullabilityInfo(nullability, parser, ref nullabilityStateIndex);
+
+            static int CountNullabilityStates(Type type)
+            {
+                Type underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+                if (underlyingType.IsGenericType)
+                {
+                    int count = 1;
+                    foreach (Type genericArgument in underlyingType.GetGenericArguments())
+                    {
+                        count += CountNullabilityStates(genericArgument);
+                    }
+                    return count;
+                }
+
+                if (underlyingType.HasElementType)
+                {
+                    return (underlyingType.IsArray ? 1 : 0) + CountNullabilityStates(underlyingType.GetElementType()!);
+                }
+
+                return type.IsValueType ? 0 : 1;
+            }
+        }
+
+        private static bool TryPopulateNullabilityInfo(NullabilityInfo nullability, NullableAttributeStateParser parser, ref int index)
+        {
+            bool isValueType = IsValueTypeOrValueTypeByRef(nullability.Type);
+            if (!isValueType)
+            {
+                var state = NullabilityState.Unknown;
+                if (!parser.ParseNullableState(index, ref state))
+                {
+                    return false;
+                }
+
+                nullability.ReadState = state;
+                nullability.WriteState = state;
+            }
+
+            if (!isValueType || (Nullable.GetUnderlyingType(nullability.Type) ?? nullability.Type).IsGenericType)
+            {
+                index++;
+            }
+
+            if (nullability.GenericTypeArguments.Length > 0)
+            {
+                foreach (NullabilityInfo genericTypeArgumentNullability in nullability.GenericTypeArguments)
+                {
+                    TryPopulateNullabilityInfo(genericTypeArgumentNullability, parser, ref index);
+                }
+            }
+            else if (nullability.ElementType is { } elementTypeNullability)
+            {
+                TryPopulateNullabilityInfo(elementTypeNullability, parser, ref index);
+            }
+
+            return true;
+        }
+
+        private static NullabilityState TranslateByte(object? value)
+        {
+            return value is byte b ? TranslateByte(b) : NullabilityState.Unknown;
+        }
+
+        private static NullabilityState TranslateByte(byte b) =>
+            b switch
+            {
+                1 => NullabilityState.NotNull,
+                2 => NullabilityState.Nullable,
+                _ => NullabilityState.Unknown
+            };
+
+        private static bool IsValueTypeOrValueTypeByRef(Type type) =>
+            type.IsValueType || ((type.IsByRef || type.IsPointer) && type.GetElementType()!.IsValueType);
+
+        private readonly struct NullableAttributeStateParser
+        {
+            private static readonly object UnknownByte = (byte)0;
+
+            private readonly object? _nullableAttributeArgument;
+
+            public NullableAttributeStateParser(object? nullableAttributeArgument)
+            {
+                this._nullableAttributeArgument = nullableAttributeArgument;
+            }
+
+            public static NullableAttributeStateParser Unknown => new(UnknownByte);
+
+            public bool ParseNullableState(int index, ref NullabilityState state)
+            {
+                switch (this._nullableAttributeArgument)
+                {
+                    case byte b:
+                        state = TranslateByte(b);
+                        return true;
+                    case ReadOnlyCollection<CustomAttributeTypedArgument> args
+                        when index < args.Count && args[index].Value is byte elementB:
+                        state = TranslateByte(elementB);
+                        return true;
+#if MONO
+                    case byte[] ba when index < ba.Length:
+                        state = TranslateByte(ba[index]);
+                        return true;
+#endif
+                    default:
+                        return false;
+                }
+            }
+        }
+    }
+
+    file static class NetstandardHelpers
+    {
+#if !NET
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+            Justification = "This is finding the MemberInfo with the same MetadataToken as specified MemberInfo. If the specified MemberInfo " +
+                            "exists and wasn't trimmed, then the current Type's MemberInfo couldn't have been trimmed.")]
+        public static MemberInfo GetMemberWithSameMetadataDefinitionAs(this Type type, MemberInfo member)
+        {
+            ArgumentNullException.ThrowIfNull(member);
+
+            const BindingFlags all = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance;
+            foreach (MemberInfo myMemberInfo in type.GetMembers(all))
+            {
+                if (myMemberInfo.HasSameMetadataDefinitionAs(member))
+                {
+                    return myMemberInfo;
+                }
+            }
+
+            throw new MissingMemberException(type.FullName, member.Name);
+        }
+
+        private static bool HasSameMetadataDefinitionAs(this MemberInfo info, MemberInfo other)
+        {
+            if (info.MetadataToken != other.MetadataToken)
+                return false;
+
+            if (!info.Module.Equals(other.Module))
+                return false;
+
+            return true;
+        }
+
+        public static bool IsGenericMethodParameter(this Type type)
+            => type.IsGenericParameter && type.DeclaringMethod is not null;
+
+#endif
+        public static ReadOnlySpan<ParameterInfo> GetParametersAsSpan(this MethodBase metaMethod)
+            => metaMethod.GetParameters();
+    }
+}

--- a/Meziantou.Polyfill.Editor/T;System.Reflection.NullabilityState.cs
+++ b/Meziantou.Polyfill.Editor/T;System.Reflection.NullabilityState.cs
@@ -1,0 +1,22 @@
+﻿// when T:System.Reflection.NullabilityInfoContext
+namespace System.Reflection
+{
+    /// <summary>
+    /// An enum that represents nullability state
+    /// </summary>
+    internal enum NullabilityState
+    {
+        /// <summary>
+        /// Nullability context not enabled (oblivious)
+        /// </summary>
+        Unknown,
+        /// <summary>
+        /// Non nullable value or reference type
+        /// </summary>
+        NotNull,
+        /// <summary>
+        /// Nullable value or reference type
+        /// </summary>
+        Nullable
+    }
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -3424,6 +3424,27 @@
       "net9.0",
       "net10.0"
     ],
+    "T:System.Reflection.NullabilityInfo": [
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
+    "T:System.Reflection.NullabilityInfoContext": [
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
+    "T:System.Reflection.NullabilityState": [
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
     "T:System.Runtime.CompilerServices.AsyncMethodBuilderAttribute": [
       "netstandard2.1",
       "net6.0",

--- a/Meziantou.Polyfill.Tests/SystemReflectionNullabilityInfoContextTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemReflectionNullabilityInfoContextTests.cs
@@ -1,0 +1,1767 @@
+﻿using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Meziantou.Polyfill.Tests;
+
+// Modified copy from https://github.com/dotnet/runtime/blob/release/10.0/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/NullabilityInfoContextTests.cs
+public class SystemReflectionNullabilityInfoContextTests
+{
+    private static readonly NullabilityInfoContext nullabilityContext = new NullabilityInfoContext();
+    private static readonly Type testType = typeof(TypeWithNotNullContext);
+    private static readonly Type genericType = typeof(GenericTest<TypeWithNotNullContext>);
+    private const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+
+    public static IEnumerable<object[]> FieldTestData()
+    {
+        yield return new object[] { "FieldNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(string) };
+        yield return new object[] { "FieldUnknown", NullabilityState.Unknown, NullabilityState.Unknown, typeof(TypeWithNotNullContext) };
+        yield return new object[] { "FieldNonNullable", NullabilityState.NotNull, NullabilityState.NotNull, typeof(SystemReflectionNullabilityInfoContextTests) };
+        yield return new object[] { "FieldValueTypeUnknown", NullabilityState.NotNull, NullabilityState.NotNull, typeof(int) };
+        yield return new object[] { "FieldValueTypeNotNull", NullabilityState.NotNull, NullabilityState.NotNull, typeof(double) };
+        yield return new object[] { "FieldValueTypeNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(int?) };
+        yield return new object[] { "FieldDisallowNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
+        yield return new object[] { "FieldAllowNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
+        yield return new object[] { "FieldDisallowNull2", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
+        yield return new object[] { "FieldAllowNull2", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
+        yield return new object[] { "FieldNotNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
+        yield return new object[] { "FieldMaybeNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
+        yield return new object[] { "FieldMaybeNull2", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
+        yield return new object[] { "FieldNotNull2", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
+    }
+
+    [Theory]
+    [MemberData(nameof(FieldTestData))]
+    internal void FieldTest(string fieldName, NullabilityState readState, NullabilityState writeState, Type type)
+    {
+        FieldInfo field = testType.GetField(fieldName, flags);
+        NullabilityInfo nullability = nullabilityContext.Create(field);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+        Assert.Empty(nullability.GenericTypeArguments);
+        Assert.Null(nullability.ElementType);
+    }
+
+    public class FI_FieldArray
+    {
+        public int[] intArray;
+        public object?[] objectArray;
+        public string?[] stringArray;
+    }
+
+    public class FI_GenericClassField<T>
+    {
+        public object?[] objectArray;
+        public T? genparamField;
+        public T?[] gparrayField;
+    }
+
+    public static IEnumerable<object[]> FieldArrayTestData()
+    {
+        yield return new object[] { "objectArray", NullabilityState.NotNull, NullabilityState.NotNull, typeof(object[]) };
+        yield return new object[] { "stringArray", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string[]) };
+    }
+
+    [Theory]
+    [MemberData(nameof(FieldArrayTestData))]
+    internal void FieldArrayTest(string fieldName, NullabilityState readState, NullabilityState writeState, Type type)
+    {
+        FieldInfo field = typeof(FI_FieldArray).GetField(fieldName, flags);
+        NullabilityInfo nullability = nullabilityContext.Create(field);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+        Assert.Empty(nullability.GenericTypeArguments);
+    }
+
+    public static IEnumerable<object[]> GenericArrayFieldTypeTestData()
+    {
+        yield return new object[] { "objectArray", NullabilityState.NotNull, NullabilityState.NotNull, typeof(object[]) };
+        yield return new object[] { "genparamField", NullabilityState.NotNull, NullabilityState.NotNull, typeof(int) };
+        yield return new object[] { "gparrayField", NullabilityState.NotNull, NullabilityState.NotNull, typeof(int[]) };
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericArrayFieldTypeTestData))]
+    internal void GenericArrayFieldTypeTest(string fieldName, NullabilityState readState, NullabilityState writeState, Type type)
+    {
+        FieldInfo field = typeof(FI_GenericClassField<int>).GetField(fieldName, flags)!;
+        NullabilityInfo nullability = nullabilityContext.Create(field);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+        Assert.Empty(nullability.GenericTypeArguments);
+    }
+
+    public static IEnumerable<object[]> EventTestData()
+    {
+        yield return new object[] { "EventNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(EventHandler) };
+        yield return new object[] { "EventUnknown", NullabilityState.Unknown, NullabilityState.Unknown, typeof(EventHandler) };
+        yield return new object[] { "EventNotNull", NullabilityState.NotNull, NullabilityState.NotNull, typeof(EventHandler) };
+    }
+
+    [Theory]
+    [MemberData(nameof(EventTestData))]
+    internal void EventTest(string eventName, NullabilityState readState, NullabilityState writeState, Type type)
+    {
+        EventInfo @event = testType.GetEvent(eventName);
+        NullabilityInfo nullability = nullabilityContext.Create(@event);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+        Assert.Empty(nullability.GenericTypeArguments);
+        Assert.Null(nullability.ElementType);
+    }
+
+    public static IEnumerable<object[]> PropertyTestData()
+    {
+        yield return new object[] { "PropertyNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(TypeWithNotNullContext) };
+        yield return new object[] { "PropertyNullableReadOnly", NullabilityState.Nullable, NullabilityState.Unknown, typeof(TypeWithNotNullContext) };
+        yield return new object[] { "PropertyUnknown", NullabilityState.Unknown, NullabilityState.Unknown, typeof(string) };
+        yield return new object[] { "PropertyNonNullable", NullabilityState.NotNull, NullabilityState.NotNull, typeof(SystemReflectionNullabilityInfoContextTests) };
+        yield return new object[] { "PropertyValueTypeUnknown", NullabilityState.NotNull, NullabilityState.NotNull, typeof(short) };
+        yield return new object[] { "PropertyValueType", NullabilityState.NotNull, NullabilityState.NotNull, typeof(float) };
+        yield return new object[] { "PropertyValueTypeNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(long?) };
+        yield return new object[] { "PropertyValueTypeDisallowNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(int?) };
+        yield return new object[] { "PropertyValueTypeAllowNull", NullabilityState.NotNull, NullabilityState.NotNull, typeof(byte) };
+        yield return new object[] { "PropertyValueTypeNotNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(int?) };
+        yield return new object[] { "PropertyValueTypeMaybeNull", NullabilityState.NotNull, NullabilityState.NotNull, typeof(byte) };
+        yield return new object[] { "PropertyDisallowNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
+        yield return new object[] { "PropertyAllowNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
+        yield return new object[] { "PropertyDisallowNull2", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
+        yield return new object[] { "PropertyAllowNull2", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
+        yield return new object[] { "PropertyNotNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
+        yield return new object[] { "PropertyMaybeNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
+        yield return new object[] { "PropertyMaybeNull2", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
+        yield return new object[] { "PropertyNotNull2", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
+        yield return new object[] { "Item", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
+    }
+
+    [Theory]
+    [MemberData(nameof(PropertyTestData))]
+    internal void PropertyTest(string propertyName, NullabilityState readState, NullabilityState writeState, Type type)
+    {
+        PropertyInfo property = testType.GetProperty(propertyName, flags);
+        NullabilityInfo nullability = nullabilityContext.Create(property);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(readState, nullabilityContext.Create(property.GetMethod.ReturnParameter).ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        if (property.SetMethod != null)
+        {
+            Assert.Equal(writeState, nullabilityContext.Create(property.SetMethod.GetParameters()[0]).WriteState);
+        }
+        Assert.Equal(type, nullability.Type);
+        Assert.Empty(nullability.GenericTypeArguments);
+        Assert.Null(nullability.ElementType);
+    }
+
+    public static IEnumerable<object[]> ArrayPropertyTestData()
+    {
+        yield return new object[] { "PropertyArrayUnknown", NullabilityState.Unknown, NullabilityState.Unknown };
+        yield return new object[] { "PropertyArrayNullNull", NullabilityState.Nullable, NullabilityState.Nullable };
+        yield return new object[] { "PropertyArrayNullNon", NullabilityState.Nullable, NullabilityState.NotNull };
+        yield return new object[] { "PropertyArrayNonNull", NullabilityState.NotNull, NullabilityState.Nullable };
+        yield return new object[] { "PropertyArrayNonNon", NullabilityState.NotNull, NullabilityState.NotNull };
+    }
+
+    [Theory]
+    [MemberData(nameof(ArrayPropertyTestData))]
+    internal void ArrayPropertyTest(string propertyName, NullabilityState elementState, NullabilityState propertyState)
+    {
+        PropertyInfo property = testType.GetProperty(propertyName, flags);
+        NullabilityInfo nullability = nullabilityContext.Create(property);
+        Assert.Equal(propertyState, nullability.ReadState);
+        Assert.NotNull(nullability.ElementType);
+        Assert.Equal(elementState, nullability.ElementType.ReadState);
+        Assert.Empty(nullability.GenericTypeArguments);
+    }
+
+    public static IEnumerable<object[]> GenericArrayPropertyTestData()
+    {
+        yield return new object[] { "PropertyArrayUnknown", NullabilityState.Unknown, NullabilityState.Unknown };
+        yield return new object[] { "PropertyArrayNullNull", NullabilityState.Nullable, NullabilityState.Nullable }; // T?[]? PropertyArrayNullNull { get; set; }
+        yield return new object[] { "PropertyArrayNullNon", NullabilityState.Nullable, NullabilityState.NotNull };   // T?[] PropertyArrayNullNon { get; set; } 
+        yield return new object[] { "PropertyArrayNonNull", NullabilityState.Nullable, NullabilityState.Nullable };  // T[]? PropertyArrayNonNull { get; set; }
+        yield return new object[] { "PropertyArrayNonNon", NullabilityState.Nullable, NullabilityState.NotNull };    // T[] PropertyArrayNonNon { get; set; }
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericArrayPropertyTestData))]
+    internal void GenericArrayPropertyTest(string propertyName, NullabilityState elementState, NullabilityState propertyState)
+    {
+        PropertyInfo property = genericType.GetProperty(propertyName, flags);
+        NullabilityInfo nullability = nullabilityContext.Create(property);
+        Assert.Equal(propertyState, nullability.ReadState);
+        Assert.NotNull(nullability.ElementType);
+        Assert.Equal(elementState, nullability.ElementType.ReadState);
+        Assert.Empty(nullability.GenericTypeArguments);
+    }
+
+    public static IEnumerable<object[]> JaggedArrayPropertyTestData()
+    {
+        yield return new object[] { "PropertyJaggedArrayUnknown", NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown };
+        yield return new object[] { "PropertyJaggedArrayNullNullNull", NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.Nullable };
+        yield return new object[] { "PropertyJaggedArrayNullNullNon", NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull };
+        yield return new object[] { "PropertyJaggedArrayNullNonNull", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+        yield return new object[] { "PropertyJaggedArrayNonNullNull", NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.Nullable };
+        yield return new object[] { "PropertyJaggedArrayNullNonNon", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull };
+        yield return new object[] { "PropertyJaggedArrayNonNonNull", NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable };
+    }
+
+    [Theory]
+    [MemberData(nameof(JaggedArrayPropertyTestData))]
+    internal void JaggedArrayPropertyTest(string propertyName, NullabilityState innermodtElementState, NullabilityState elementState, NullabilityState propertyState)
+    {
+        PropertyInfo property = testType.GetProperty(propertyName, flags);
+        NullabilityInfo nullability = nullabilityContext.Create(property);
+        Assert.Equal(propertyState, nullability.ReadState);
+        Assert.NotNull(nullability.ElementType);
+        Assert.Equal(elementState, nullability.ElementType.ReadState);
+        Assert.NotNull(nullability.ElementType.ElementType);
+        Assert.Equal(innermodtElementState, nullability.ElementType.ElementType.ReadState);
+        Assert.Empty(nullability.GenericTypeArguments);
+    }
+
+    public static IEnumerable<object[]> TuplePropertyTestData()
+    {
+        yield return new object[] { "PropertyTupleUnknown", NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown };
+        yield return new object[] { "PropertyTupleNullNullNullNull", NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.Nullable };
+        yield return new object[] { "PropertyTupleNonNullNonNon", NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull };
+        yield return new object[] { "PropertyTupleNullNonNullNull", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.Nullable };
+        yield return new object[] { "PropertyTupleNonNullNonNull", NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+        yield return new object[] { "PropertyTupleNonNonNonNon", NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull };
+    }
+
+    [Theory]
+    [MemberData(nameof(TuplePropertyTestData))]
+    internal void TuplePropertyTest(string propertyName, NullabilityState genericParam1, NullabilityState genericParam2, NullabilityState genericParam3, NullabilityState propertyState)
+    {
+        PropertyInfo property = testType.GetProperty(propertyName, flags);
+        NullabilityInfo nullability = nullabilityContext.Create(property);
+        Assert.Equal(propertyState, nullability.ReadState);
+        Assert.NotEmpty(nullability.GenericTypeArguments);
+        Assert.Equal(genericParam1, nullability.GenericTypeArguments[0].ReadState);
+        Assert.Equal(genericParam2, nullability.GenericTypeArguments[1].ReadState);
+        Assert.Equal(genericParam3, nullability.GenericTypeArguments[2].ReadState);
+        Assert.Null(nullability.ElementType);
+    }
+
+    public static IEnumerable<object[]> GenericTuplePropertyTestData()
+    {
+        yield return new object[] { "PropertyTupleUnknown", NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown };
+        yield return new object[] { "PropertyTupleNullNullNullNull", NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.Nullable }; // Tuple<T?, string?, string?>?
+        yield return new object[] { "PropertyTupleNonNullNonNon", NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull };      // Tuple<T, T?, string>
+        yield return new object[] { "PropertyTupleNullNonNullNull", NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.Nullable };  // Tuple<string?, T, T?>?
+        yield return new object[] { "PropertyTupleNonNullNonNull", NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };    // Tuple<T, string?, string>?
+        yield return new object[] { "PropertyTupleNonNonNonNon", NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull };        // Tuple<string, string, T>
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericTuplePropertyTestData))]
+    internal void GenericTuplePropertyTest(string propertyName, NullabilityState genericParam1, NullabilityState genericParam2, NullabilityState genericParam3, NullabilityState propertyState)
+    {
+        PropertyInfo property = genericType.GetProperty(propertyName, flags);
+        NullabilityInfo nullability = nullabilityContext.Create(property);
+        Assert.Equal(propertyState, nullability.ReadState);
+        Assert.NotEmpty(nullability.GenericTypeArguments);
+        Assert.Equal(genericParam1, nullability.GenericTypeArguments[0].ReadState);
+        Assert.Equal(genericParam2, nullability.GenericTypeArguments[1].ReadState);
+        Assert.Equal(genericParam3, nullability.GenericTypeArguments[2].ReadState);
+        Assert.Null(nullability.ElementType);
+    }
+
+    public static IEnumerable<object[]> DictionaryPropertyTestData()
+    {
+        yield return new object[] { "PropertyDictionaryUnknown", NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown };
+        yield return new object[] { "PropertyDictionaryNullNullNullNon", NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull };
+        yield return new object[] { "PropertyDictionaryNonNullNonNull", NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+        yield return new object[] { "PropertyDictionaryNullNonNonNull", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable };
+        yield return new object[] { "PropertyDictionaryNonNullNonNon", NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull };
+        yield return new object[] { "PropertyDictionaryNonNonNonNull", NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable };
+        yield return new object[] { "PropertyDictionaryNonNonNonNon", NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull };
+    }
+
+    [Theory]
+    [MemberData(nameof(DictionaryPropertyTestData))]
+    internal void DictionaryPropertyTest(string propertyName, NullabilityState keyState, NullabilityState valueElement, NullabilityState valueState, NullabilityState propertyState)
+    {
+        PropertyInfo property = testType.GetProperty(propertyName, flags);
+        NullabilityInfo nullability = nullabilityContext.Create(property);
+        Assert.Equal(propertyState, nullability.ReadState);
+        Assert.NotEmpty(nullability.GenericTypeArguments);
+        Assert.Equal(keyState, nullability.GenericTypeArguments[0].ReadState);
+        Assert.Equal(valueState, nullability.GenericTypeArguments[1].ReadState);
+        Assert.Equal(valueElement, nullability.GenericTypeArguments[1].ElementType.ReadState);
+        Assert.Null(nullability.ElementType);
+    }
+
+    public static IEnumerable<object[]> GenericDictionaryPropertyTestData()
+    {
+        yield return new object[] { "PropertyDictionaryUnknown", NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown };
+        yield return new object[] { "PropertyDictionaryNullNullNullNon", NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull }; // IDictionary<T?, string?[]?> PropertyDictionaryNullNullNullNon { get; set; }
+        yield return new object[] { "PropertyDictionaryNonNullNonNull", NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable }; // IDictionary<Type, T?[]>? PropertyDictionaryNonNullNonNull
+        yield return new object[] { "PropertyDictionaryNullNonNonNull", NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable }; // IDictionary<T?, T[]>? PropertyDictionaryNullNonNonNull
+        yield return new object[] { "PropertyDictionaryNonNullNonNon", NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull }; // IDictionary<Type, T?[]> PropertyDictionaryNonNullNonNon
+        yield return new object[] { "PropertyDictionaryNonNonNonNull", NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable }; // IDictionary<T, T[]>? PropertyDictionaryNonNonNonNull
+        yield return new object[] { "PropertyDictionaryNonNonNonNon", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull }; // IDictionary<T, string[]> PropertyDictionaryNonNonNonNon
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericDictionaryPropertyTestData))]
+    internal void GenericDictionaryPropertyTest(string propertyName, NullabilityState keyState, NullabilityState valueElement, NullabilityState valueState, NullabilityState propertyState)
+    {
+        PropertyInfo property = genericType.GetProperty(propertyName, flags);
+        NullabilityInfo nullability = nullabilityContext.Create(property);
+        Assert.Equal(propertyState, nullability.ReadState);
+        Assert.NotEmpty(nullability.GenericTypeArguments);
+        Assert.Equal(keyState, nullability.GenericTypeArguments[0].ReadState);
+        Assert.Equal(valueState, nullability.GenericTypeArguments[1].ReadState);
+        Assert.Equal(valueElement, nullability.GenericTypeArguments[1].ElementType.ReadState);
+        Assert.Null(nullability.ElementType);
+    }
+
+    public static IEnumerable<object[]> GenericPropertyReferenceTypeTestData()
+    {
+        yield return new object[] { "PropertyNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(TypeWithNotNullContext) };
+        yield return new object[] { "PropertyUnknown", NullabilityState.Unknown, NullabilityState.Unknown, typeof(TypeWithNotNullContext) };
+        yield return new object[] { "PropertyNonNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(TypeWithNotNullContext) };
+        yield return new object[] { "PropertyDisallowNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(TypeWithNotNullContext) };
+        yield return new object[] { "PropertyAllowNull", NullabilityState.Nullable, NullabilityState.Nullable, typeof(TypeWithNotNullContext) };
+        yield return new object[] { "PropertyMaybeNull", NullabilityState.Nullable, NullabilityState.Nullable, typeof(TypeWithNotNullContext) };
+    }
+
+#nullable enable
+    [Theory]
+    [MemberData(nameof(GenericPropertyReferenceTypeTestData))]
+    internal void GenericPropertyReferenceTypeTest(string fieldName, NullabilityState readState, NullabilityState writeState, Type type)
+    {
+        PropertyInfo property = typeof(GenericTest<TypeWithNotNullContext?>).GetProperty(fieldName, flags)!;
+        NullabilityInfo nullability = nullabilityContext.Create(property);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+        Assert.Empty(nullability.GenericTypeArguments);
+        Assert.Null(nullability.ElementType);
+
+        property = typeof(GenericTest<TypeWithNotNullContext>).GetProperty(fieldName, flags)!;
+        nullability = nullabilityContext.Create(property);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+
+        property = typeof(GenericTest<>).GetProperty(fieldName, flags)!;
+        nullability = nullabilityContext.Create(property);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+    }
+
+    public static IEnumerable<object[]> GenericFieldReferenceTypeTestData()
+    {
+        yield return new object[] { "FieldNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(TypeWithNotNullContext) };
+        yield return new object[] { "FieldUnknown", NullabilityState.Unknown, NullabilityState.Unknown, typeof(TypeWithNotNullContext) };
+        yield return new object[] { "FieldNonNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(TypeWithNotNullContext) };
+        yield return new object[] { "FieldDisallowNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(TypeWithNotNullContext) };
+        yield return new object[] { "FieldAllowNull", NullabilityState.Nullable, NullabilityState.Nullable, typeof(TypeWithNotNullContext) };
+        yield return new object[] { "FieldMaybeNull", NullabilityState.Nullable, NullabilityState.Nullable, typeof(TypeWithNotNullContext) };
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericFieldReferenceTypeTestData))]
+    internal void GenericFieldReferenceTypeTest(string fieldName, NullabilityState readState, NullabilityState writeState, Type type)
+    {
+        FieldInfo field = typeof(GenericTest<TypeWithNotNullContext?>).GetField(fieldName, flags)!;
+        NullabilityInfo nullability = nullabilityContext.Create(field);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+        Assert.Empty(nullability.GenericTypeArguments);
+        Assert.Null(nullability.ElementType);
+
+        field = typeof(GenericTest<TypeWithNotNullContext>).GetField(fieldName, flags)!;
+        nullability = nullabilityContext.Create(field);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+
+        field = typeof(GenericTest<>).GetField(fieldName, flags)!;
+        nullability = nullabilityContext.Create(field);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+    }
+
+    public static IEnumerable<object[]> GenericFieldValueTypeTestData()
+    {
+        yield return new object[] { "FieldNullable", typeof(int) };
+        yield return new object[] { "FieldUnknown", typeof(int) };
+        yield return new object[] { "FieldNonNullable", typeof(int) };
+        yield return new object[] { "FieldDisallowNull", typeof(int) };
+        yield return new object[] { "FieldAllowNull", typeof(int) };
+        yield return new object[] { "FieldMaybeNull", typeof(int) };
+        yield return new object[] { "FieldNotNull", typeof(int) };
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericFieldValueTypeTestData))]
+    public void GenericFieldValueTypeTest(string fieldName, Type type)
+    {
+        FieldInfo field = typeof(GenericTest<int>).GetField(fieldName, flags)!;
+        NullabilityInfo nullability = nullabilityContext.Create(field);
+        Assert.Equal(NullabilityState.NotNull, nullability.ReadState);
+        Assert.Equal(NullabilityState.NotNull, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+    }
+
+    public static IEnumerable<object[]> GenericFieldNullableValueTypeTestData()
+    {
+        yield return new object[] { "FieldNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(int?) };
+        yield return new object[] { "FieldUnknown", NullabilityState.Nullable, NullabilityState.Nullable, typeof(int?) };
+        yield return new object[] { "FieldNonNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(int?) };
+        yield return new object[] { "FieldDisallowNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(int?) };
+        yield return new object[] { "FieldAllowNull", NullabilityState.Nullable, NullabilityState.Nullable, typeof(int?) };
+        yield return new object[] { "FieldMaybeNull", NullabilityState.Nullable, NullabilityState.Nullable, typeof(int?) };
+        yield return new object[] { "FieldNotNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(int?) };
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericFieldNullableValueTypeTestData))]
+    internal void GenericFieldNullableValueTypeTest(string fieldName, NullabilityState readState, NullabilityState writeState, Type type)
+    {
+        FieldInfo field = typeof(GenericTest<int?>).GetField(fieldName, flags)!;
+        NullabilityInfo nullability = nullabilityContext.Create(field);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+    }
+
+    public static IEnumerable<object[]> GenericNotNullConstraintFieldsTestData()
+    {
+        yield return new object[] { "FieldNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(string) };
+        yield return new object[] { "FieldUnknown", NullabilityState.Unknown, NullabilityState.Unknown, typeof(string) };
+        yield return new object[] { "FieldNullableEnabled", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericNotNullConstraintFieldsTestData))]
+    internal void GenericNotNullConstraintFieldsTest(string fieldName, NullabilityState readState, NullabilityState writeState, Type type)
+    {
+        FieldInfo field = typeof(GenericTestConstrainedNotNull<string>).GetField(fieldName, flags)!;
+        NullabilityInfo nullability = nullabilityContext.Create(field);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+    }
+
+    public static IEnumerable<object[]> GenericNotnullConstraintPropertiesTestData()
+    {
+        yield return new object[] { "PropertyNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(string) };
+        yield return new object[] { "PropertyUnknown", NullabilityState.Unknown, NullabilityState.Unknown, typeof(string) };
+        yield return new object[] { "PropertyNullableEnabled", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericNotnullConstraintPropertiesTestData))]
+    internal void GenericNotNullConstraintPropertiesTest(string propertyName, NullabilityState readState, NullabilityState writeState, Type type)
+    {
+        PropertyInfo property = typeof(GenericTestConstrainedNotNull<string>).GetProperty(propertyName, flags)!;
+        NullabilityInfo nullability = nullabilityContext.Create(property);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+    }
+
+    public static IEnumerable<object[]> GenericStructConstraintFieldsTestData()
+    {
+        yield return new object[] { "FieldNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(int?) };
+        yield return new object[] { "FieldUnknown", NullabilityState.NotNull, NullabilityState.NotNull, typeof(int) };
+        yield return new object[] { "FieldNullableEnabled", NullabilityState.NotNull, NullabilityState.NotNull, typeof(int) };
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericStructConstraintFieldsTestData))]
+    internal void GenericStructConstraintFieldsTest(string fieldName, NullabilityState readState, NullabilityState writeState, Type type)
+    {
+        FieldInfo field = typeof(GenericTestConstrainedStruct<int>).GetField(fieldName, flags)!;
+        NullabilityInfo nullability = nullabilityContext.Create(field);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+    }
+
+    public static IEnumerable<object[]> GenericStructConstraintPropertiesTestData()
+    {
+        yield return new object[] { "PropertyNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(int?) };
+        yield return new object[] { "PropertyUnknown", NullabilityState.NotNull, NullabilityState.NotNull, typeof(int) };
+        yield return new object[] { "PropertyNullableEnabled", NullabilityState.NotNull, NullabilityState.NotNull, typeof(int) };
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericStructConstraintPropertiesTestData))]
+    internal void GenericStructConstraintPropertiesTest(string propertyName, NullabilityState readState, NullabilityState writeState, Type type)
+    {
+        PropertyInfo property = typeof(GenericTestConstrainedStruct<int>).GetProperty(propertyName, flags)!;
+        NullabilityInfo nullability = nullabilityContext.Create(property);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+    }
+
+    [Fact]
+    public void GenericListTest()
+    {
+        Type listNullable = typeof(List<string?>);
+        MethodInfo addNullable = listNullable.GetMethod("Add")!;
+        NullabilityInfo nullability = nullabilityContext.Create(addNullable.GetParameters()[0]);
+        Assert.Equal(NullabilityState.Nullable, nullability.ReadState);
+        Assert.Equal(NullabilityState.Nullable, nullability.WriteState);
+        Assert.Equal(typeof(string), nullability.Type);
+
+        Type listNotNull = typeof(List<string>);
+        MethodInfo addNotNull = listNotNull.GetMethod("Add")!;
+        nullability = nullabilityContext.Create(addNotNull.GetParameters()[0]);
+        Assert.Equal(NullabilityState.Nullable, nullability.ReadState);
+        Assert.Equal(typeof(string), nullability.Type);
+
+        Type listOpen = typeof(List<>);
+        MethodInfo addOpen = listOpen.GetMethod("Add")!;
+        nullability = nullabilityContext.Create(addOpen.GetParameters()[0]);
+        Assert.Equal(NullabilityState.Nullable, nullability.ReadState);
+    }
+
+    [Fact]
+    public void GenericListAndDictionaryFieldTest()
+    {
+        Type typeNullable = typeof(GenericTest<string?>);
+        FieldInfo listOfTNullable = typeNullable.GetField("FieldListOfT")!;
+        NullabilityInfo listNullability = nullabilityContext.Create(listOfTNullable);
+        Assert.Equal(NullabilityState.Nullable, listNullability.GenericTypeArguments[0].ReadState);
+        Assert.Equal(typeof(string), listNullability.GenericTypeArguments[0].Type);
+
+        FieldInfo dictStringToTNullable = typeNullable.GetField("FieldDictionaryStringToT")!;
+        NullabilityInfo dictNullability = nullabilityContext.Create(dictStringToTNullable);
+        Assert.Equal(NullabilityState.NotNull, dictNullability.GenericTypeArguments[0].ReadState);
+        Assert.Equal(NullabilityState.Nullable, dictNullability.GenericTypeArguments[1].ReadState);
+        Assert.Equal(typeof(string), dictNullability.GenericTypeArguments[1].Type);
+
+        Type typeNonNull = typeof(GenericTest<string>);
+        FieldInfo listOfTNotNull = typeNonNull.GetField("FieldListOfT")!;
+        listNullability = nullabilityContext.Create(listOfTNotNull);
+        Assert.Equal(NullabilityState.Nullable, listNullability.GenericTypeArguments[0].ReadState);
+        Assert.Equal(typeof(string), listNullability.GenericTypeArguments[0].Type);
+
+        FieldInfo dictStringToTNotNull = typeNonNull.GetField("FieldDictionaryStringToT")!;
+        dictNullability = nullabilityContext.Create(dictStringToTNotNull);
+        Assert.Equal(NullabilityState.NotNull, dictNullability.GenericTypeArguments[0].ReadState);
+        Assert.Equal(NullabilityState.Nullable, dictNullability.GenericTypeArguments[1].ReadState);
+        Assert.Equal(typeof(string), dictNullability.GenericTypeArguments[1].Type);
+
+        Type typeOpen = typeof(GenericTest<>);
+        FieldInfo listOfTOpen = typeOpen.GetField("FieldListOfT")!;
+        listNullability = nullabilityContext.Create(listOfTOpen);
+        Assert.Equal(NullabilityState.Nullable, listNullability.GenericTypeArguments[0].ReadState);
+        // Assert.Equal(typeof(T), listNullability.TypeArguments[0].Type);
+
+        FieldInfo dictStringToTOpen = typeOpen.GetField("FieldDictionaryStringToT")!;
+        dictNullability = nullabilityContext.Create(dictStringToTOpen);
+        Assert.Equal(NullabilityState.NotNull, dictNullability.GenericTypeArguments[0].ReadState);
+        Assert.Equal(NullabilityState.Nullable, dictNullability.GenericTypeArguments[1].ReadState);
+    }
+
+    public static IEnumerable<object[]> MethodReturnParameterTestData()
+    {
+        yield return new object[] { "MethodReturnsUnknown", NullabilityState.Unknown, NullabilityState.Unknown };
+        yield return new object[] { "MethodReturnsNullNon", NullabilityState.Nullable, NullabilityState.NotNull };
+        yield return new object[] { "MethodReturnsNullNull", NullabilityState.Nullable, NullabilityState.Nullable };
+        yield return new object[] { "MethodReturnsNonNull", NullabilityState.NotNull, NullabilityState.Nullable };
+        yield return new object[] { "MethodReturnsNonNotNull", NullabilityState.NotNull, NullabilityState.NotNull };
+        yield return new object[] { "MethodReturnsNonMaybeNull", NullabilityState.NotNull, NullabilityState.Nullable };
+        yield return new object[] { "MethodReturnsNonNon", NullabilityState.NotNull, NullabilityState.NotNull };
+    }
+
+    [Theory]
+    [MemberData(nameof(MethodReturnParameterTestData))]
+    internal void MethodReturnParameterTest(string methodName, NullabilityState elementState, NullabilityState readState)
+    {
+        MethodInfo method = testType.GetMethod(methodName, flags)!;
+        NullabilityInfo nullability = nullabilityContext.Create(method.ReturnParameter);
+        Assert.Equal(readState, nullability.ReadState);
+        //Assert.Equal(readState, nullability.WriteState);
+        Assert.NotNull(nullability.ElementType);
+        Assert.Equal(elementState, nullability.ElementType!.ReadState);
+        Assert.Empty(nullability.GenericTypeArguments);
+    }
+
+    public static IEnumerable<object[]> MethodReturnsTupleTestData()
+    {
+        // public Tuple<string?, string>? MethodReturnsTupleNullNonNull() => null;
+        yield return new object[] { "MethodReturnsTupleNullNonNull", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+        // public Tuple<string?, int> MethodReturnsTupleNullNonNot() => null!
+        yield return new object[] { "MethodReturnsTupleNullNonNot", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull };
+        // public (int?, string)? MethodReturnsValueTupleNullNonNull() => null;
+        yield return new object[] { "MethodReturnsValueTupleNullNonNull", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+        // public (string?, string) MethodReturnsValueTupleNullNonNon() => (null, string.Empty);
+        yield return new object[] { "MethodReturnsValueTupleNullNonNon", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull };
+    }
+
+    [Theory]
+    [MemberData(nameof(MethodReturnsTupleTestData))]
+    internal void MethodReturnsTupleTest(string methodName, NullabilityState param1, NullabilityState param2, NullabilityState readState)
+    {
+        MethodInfo method = testType.GetMethod(methodName, flags)!;
+        NullabilityInfo nullability = nullabilityContext.Create(method.ReturnParameter);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Null(nullability.ElementType);
+        Assert.Equal(param1, nullability.GenericTypeArguments[0].ReadState);
+        Assert.Equal(param2, nullability.GenericTypeArguments[1].ReadState);
+    }
+
+    public static IEnumerable<object[]> MethodGenericReturnParameterTestData()
+    {
+        yield return new object[] { "MethodReturnsUnknown", NullabilityState.Unknown, NullabilityState.Unknown };
+        yield return new object[] { "MethodReturnsGeneric", NullabilityState.Nullable, NullabilityState.Unknown };
+        yield return new object[] { "MethodReturnsNullGeneric", NullabilityState.Nullable, NullabilityState.Unknown };
+        yield return new object[] { "MethodReturnsGenericNotNull", NullabilityState.NotNull, NullabilityState.Unknown };
+        yield return new object[] { "MethodReturnsGenericMaybeNull", NullabilityState.Nullable, NullabilityState.Unknown };
+        yield return new object[] { "MethodNonNullListNullGeneric", NullabilityState.NotNull, NullabilityState.Nullable };
+        yield return new object[] { "MethodNullListNonNullGeneric", NullabilityState.Nullable, NullabilityState.Nullable };
+    }
+
+    [Theory]
+    [MemberData(nameof(MethodGenericReturnParameterTestData))]
+    internal void MethodGenericReturnParameterTest(string methodName, NullabilityState readState, NullabilityState elementState)
+    {
+        MethodInfo method = typeof(GenericTest<TypeWithNotNullContext?>).GetMethod(methodName, flags)!;
+        NullabilityInfo nullability = nullabilityContext.Create(method.ReturnParameter);
+        Assert.Equal(readState, nullability.ReadState);
+        if (nullability.GenericTypeArguments.Length > 0)
+        {
+            Assert.Equal(elementState, nullability.GenericTypeArguments[0].ReadState);
+        }
+    }
+
+    public static IEnumerable<object[]> MethodParametersTestData()
+    {
+        yield return new object[] { "MethodParametersUnknown", NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown };
+        yield return new object[] { "MethodNullNonNullNonNon", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull };
+        yield return new object[] { "MethodNonNullNonNullNotNull", NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull };
+        yield return new object[] { "MethodNullNonNullNullNon", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull };
+        yield return new object[] { "MethodAllowNullNonNonNonNull", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable };
+    }
+
+    [Theory]
+    [MemberData(nameof(MethodParametersTestData))]
+    internal void MethodParametersTest(string methodName, NullabilityState stringState, NullabilityState dictKey, NullabilityState dictValueElement, NullabilityState dictValue, NullabilityState dictionaryState)
+    {
+        ParameterInfo[] parameters = testType.GetMethod(methodName, flags)!.GetParameters();
+        NullabilityInfo stringNullability = nullabilityContext.Create(parameters[0]);
+        NullabilityInfo dictionaryNullability = nullabilityContext.Create(parameters[1]);
+        Assert.Equal(stringState, stringNullability.WriteState);
+        Assert.Equal(dictionaryState, dictionaryNullability.ReadState);
+        Assert.NotEmpty(dictionaryNullability.GenericTypeArguments);
+        Assert.Equal(dictKey, dictionaryNullability.GenericTypeArguments[0].ReadState);
+        Assert.Equal(dictValue, dictionaryNullability.GenericTypeArguments[1].ReadState);
+        Assert.Equal(dictValueElement, dictionaryNullability.GenericTypeArguments[1].ElementType!.ReadState);
+        Assert.Null(dictionaryNullability.ElementType);
+    }
+
+    public static IEnumerable<object[]> MethodByRefParametersTestData() => new[]
+    {
+            new object[] { -1, NullabilityState.Nullable }, // ref readonly int?
+            new object[] { 0, NullabilityState.Nullable }, // out int? a
+            new object[] { 1, NullabilityState.NotNull }, // out string b
+            new object[] { 2, NullabilityState.Nullable }, // ref object? c
+            new object[] { 3, NullabilityState.NotNull }, // ref Type d
+            new object[] { 4, NullabilityState.Nullable }, // in decimal? e
+            new object[] { 5, NullabilityState.NotNull }, // in ICloneable f
+        };
+
+    [Theory]
+    [MemberData(nameof(MethodByRefParametersTestData))]
+    internal void MethodByRefParametersTest(int parameterIndex, NullabilityState state)
+    {
+        MethodInfo method = typeof(TypeWithNotNullContext).GetMethod(nameof(TypeWithNotNullContext.MethodWithByRefs))!;
+        ParameterInfo parameter = parameterIndex == -1 ? method.ReturnParameter : method.GetParameters()[parameterIndex];
+        NullabilityInfo info = nullabilityContext.Create(parameter);
+
+        Assert.Equal(parameter.ParameterType, info.Type);
+        Assert.Equal(state, info.ReadState);
+        Assert.Equal(state, info.WriteState);
+    }
+
+    public static IEnumerable<object?[]> MethodGenericByRefParametersTestData() => new[]
+{
+            // ref Tuple<int?, string, IDisposable?>
+            new object?[] { -1, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable },
+            // out KeyValuePair<string?, object> a
+            new object?[] { 0, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, null }, 
+            // ref Tuple<Type?, decimal>? b
+            new object?[] { 1, NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull, null },
+            // in KeyValuePair<ICloneable, IFormatProvider?>? c
+            new object?[] { 2, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, null },
+        };
+
+    [Theory]
+    [MemberData(nameof(MethodGenericByRefParametersTestData))]
+    internal void MethodGenericByRefParametersTest(
+        int parameterIndex,
+        NullabilityState state,
+        NullabilityState genericArgument0State,
+        NullabilityState genericArgument1State,
+        NullabilityState? genericArgument2State)
+    {
+        MethodInfo method = typeof(TypeWithNotNullContext).GetMethod(nameof(TypeWithNotNullContext.MethodWithGenericByRefs))!;
+        ParameterInfo parameter = parameterIndex == -1 ? method.ReturnParameter : method.GetParameters()[parameterIndex];
+        NullabilityInfo info = nullabilityContext.Create(parameter);
+        Assert.Equal(parameter.ParameterType, info.Type);
+        Assert.Equal(state, info.ReadState);
+        Assert.Equal(state, info.WriteState);
+
+        NullabilityState?[] genericArgumentStates = new[] { genericArgument0State, genericArgument1State, genericArgument2State };
+        for (var i = 0; i < genericArgumentStates.Length; ++i)
+        {
+            if (genericArgumentStates[i] is null)
+            {
+                Assert.Equal(i, info.GenericTypeArguments.Length);
+                break;
+            }
+
+            Assert.Equal(genericArgumentStates[i], info.GenericTypeArguments[i].ReadState);
+            Assert.Equal(genericArgumentStates[i], info.GenericTypeArguments[i].WriteState);
+        }
+    }
+
+    [Fact]
+    public void ConstrainedGenericMethodWithByRefTest()
+    {
+        // ref T ConstrainedGenericMethodWithByRef<T>(out T[] array) where T : class?
+        MethodInfo method = typeof(TypeWithNotNullContext).GetMethod(nameof(TypeWithNotNullContext.ConstrainedGenericMethodWithByRef))!
+            .MakeGenericMethod(typeof(string));
+
+        NullabilityInfo info = nullabilityContext.Create(method.ReturnParameter);
+        Assert.Equal(method.ReturnType, info.Type);
+        Assert.Equal(NullabilityState.Nullable, info.ReadState);
+        Assert.Equal(NullabilityState.Nullable, info.WriteState);
+
+        info = nullabilityContext.Create(method.GetParameters()[0]);
+        Assert.Equal(typeof(string[]).MakeByRefType(), info.Type);
+        Assert.Equal(NullabilityState.NotNull, info.ReadState);
+        Assert.Equal(NullabilityState.NotNull, info.WriteState);
+        Assert.Equal(typeof(string), info.ElementType!.Type);
+        Assert.Equal(NullabilityState.Nullable, info.ElementType.ReadState);
+        Assert.Equal(NullabilityState.Nullable, info.ElementType.WriteState);
+    }
+
+    [Fact]
+    public void MethodWithPointersTest()
+    {
+        // MethodWithPointers(int* a, int?* b)
+        MethodInfo method = typeof(TypeWithNotNullContext).GetMethod(nameof(TypeWithNotNullContext.MethodWithPointers))!;
+        ParameterInfo[] parameters = method.GetParameters();
+
+        NullabilityInfo info = nullabilityContext.Create(parameters[0]);
+        Assert.Equal(parameters[0].ParameterType, info.Type);
+        Assert.Equal(NullabilityState.NotNull, info.ReadState);
+        Assert.Equal(NullabilityState.NotNull, info.WriteState);
+
+        info = nullabilityContext.Create(parameters[1]);
+        Assert.Equal(parameters[1].ParameterType, info.Type);
+        Assert.Equal(NullabilityState.Nullable, info.ReadState);
+        Assert.Equal(NullabilityState.Nullable, info.WriteState);
+    }
+
+    [Fact]
+    public unsafe void GenericMethodWithPointersTest()
+    {
+        // Dummy call to MakeGenericMethod to make the code generated ahead of time 
+        if (string.Empty.Length > 0)
+            new TypeWithNotNullContext().GenericMethodWithPointers<float>(null, null);
+
+        // GenericMethodWithPointers<T>(T* a, T?* b)
+        MethodInfo method = typeof(TypeWithNotNullContext).GetMethod(nameof(TypeWithNotNullContext.GenericMethodWithPointers))!
+            .MakeGenericMethod(typeof(float));
+        ParameterInfo[] parameters = method.GetParameters();
+
+        NullabilityInfo info = nullabilityContext.Create(parameters[0]);
+        Assert.Equal(parameters[0].ParameterType, info.Type);
+        Assert.Equal(NullabilityState.NotNull, info.ReadState);
+        Assert.Equal(NullabilityState.NotNull, info.WriteState);
+
+        info = nullabilityContext.Create(parameters[1]);
+        Assert.Equal(parameters[1].ParameterType, info.Type);
+        Assert.Equal(NullabilityState.Nullable, info.ReadState);
+        Assert.Equal(NullabilityState.Nullable, info.WriteState);
+    }
+
+    public static IEnumerable<object[]> MethodGenericParametersTestData()
+    {
+        yield return new object[] { "MethodParametersUnknown", NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown };
+        yield return new object[] { "MethodArgsNullGenericNullDictValueGeneric", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.Nullable };
+        yield return new object[] { "MethodArgsGenericDictValueNullGeneric", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull };
+    }
+
+    [Theory]
+    [MemberData(nameof(MethodGenericParametersTestData))]
+    internal void MethodGenericParametersTest(string methodName, NullabilityState param1State, NullabilityState dictKey, NullabilityState dictValue, NullabilityState dictionaryState)
+    {
+        ParameterInfo[] parameters = typeof(GenericTest<TypeWithNotNullContext>).GetMethod(methodName, flags)!.GetParameters();
+        NullabilityInfo stringNullability = nullabilityContext.Create(parameters[0]);
+        NullabilityInfo dictionaryNullability = nullabilityContext.Create(parameters[1]);
+        Assert.Equal(param1State, stringNullability.WriteState);
+        Assert.Equal(dictionaryState, dictionaryNullability.ReadState);
+        Assert.NotEmpty(dictionaryNullability.GenericTypeArguments);
+        Assert.Equal(dictKey, dictionaryNullability.GenericTypeArguments[0].ReadState);
+        Assert.Equal(dictValue, dictionaryNullability.GenericTypeArguments[1].ReadState);
+    }
+
+    [Fact]
+    public void PropertyWithByRefGenericParametersTest()
+    {
+        // ref T? this[in T a, in List<T?> b] { get; }
+        PropertyInfo property = typeof(GenericTest<string>).GetProperty("Item", typeof(string).MakeByRefType())!;
+
+        NullabilityInfo info = nullabilityContext.Create(property);
+        Assert.Equal(typeof(string).MakeByRefType(), info.Type);
+        Assert.Equal(NullabilityState.Nullable, info.ReadState);
+        Assert.Equal(NullabilityState.Unknown, info.WriteState);
+
+        info = nullabilityContext.Create(property.GetIndexParameters()[0]);
+        Assert.Equal(typeof(string).MakeByRefType(), info.Type);
+        // in T a is nullable because T is not constrained
+        Assert.Equal(NullabilityState.Nullable, info.ReadState);
+        Assert.Equal(NullabilityState.Nullable, info.WriteState);
+
+        info = nullabilityContext.Create(property.GetIndexParameters()[1]);
+        Assert.Equal(typeof(List<string>).MakeByRefType(), info.Type);
+        Assert.Equal(NullabilityState.NotNull, info.ReadState);
+        Assert.Equal(NullabilityState.NotNull, info.WriteState);
+        info = Assert.Single(info.GenericTypeArguments);
+        Assert.Equal(typeof(string), info.Type);
+        Assert.Equal(NullabilityState.Nullable, info.ReadState);
+        Assert.Equal(NullabilityState.Nullable, info.WriteState);
+    }
+
+    public static IEnumerable<object[]> StringTypeTestData()
+    {
+        yield return new object[] { "Format", NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.Nullable, new Type[] { typeof(string), typeof(object), typeof(object) } };
+        yield return new object[] { "ReplaceCore", NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown, new Type[] { typeof(string), typeof(string), typeof(CompareInfo), typeof(CompareOptions) } };
+        yield return new object[] { "Join", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull, new Type[] { typeof(string), typeof(String?[]), typeof(int), typeof(int) } };
+    }
+
+    [Theory]
+    [MemberData(nameof(StringTypeTestData))]
+    internal void NullablePublicOnlyStringTypeTest(string methodName, NullabilityState param1State, NullabilityState param2State, NullabilityState param3State, Type[] types)
+    {
+        ParameterInfo[] parameters = typeof(string).GetMethod(methodName, flags, types)!.GetParameters();
+        NullabilityInfo param1 = nullabilityContext.Create(parameters[0]);
+        NullabilityInfo param2 = nullabilityContext.Create(parameters[1]);
+        NullabilityInfo param3 = nullabilityContext.Create(parameters[2]);
+        Assert.Equal(param1State, param1.ReadState);
+        Assert.Equal(param2State, param2.ReadState);
+        Assert.Equal(param3State, param3.ReadState);
+        if (param2.ElementType != null)
+        {
+            Assert.Equal(NullabilityState.Nullable, param2.ElementType.ReadState);
+        }
+    }
+
+    [Fact]
+    public void NullablePublicOnlyOtherTypesTest()
+    {
+        FieldInfo privateNullableField = typeof(AppDomain).GetField("s_domain", flags)!;
+        NullabilityInfo info = nullabilityContext.Create(privateNullableField);
+        Assert.Equal(NullabilityState.Unknown, info.ReadState);
+        Assert.Equal(NullabilityState.Unknown, info.WriteState);
+
+        Type type = typeof(Type);
+        MethodInfo internalNotNullableMethod = type.GetMethod("GetRootElementType", flags)!;
+        info = nullabilityContext.Create(internalNotNullableMethod.ReturnParameter);
+        Assert.Equal(NullabilityState.NotNull, info.ReadState);
+        Assert.Equal(NullabilityState.NotNull, info.WriteState);
+
+        PropertyInfo publicNullableProperty = type.GetProperty("DeclaringType", flags)!;
+        info = nullabilityContext.Create(publicNullableProperty);
+        Assert.Equal(NullabilityState.Nullable, info.ReadState);
+        Assert.Equal(NullabilityState.Unknown, info.WriteState);
+
+        MethodInfo protectedNullableReturnMethod = type.GetMethod("GetPropertyImpl", flags)!;
+        info = nullabilityContext.Create(protectedNullableReturnMethod.ReturnParameter);
+        Assert.Equal(NullabilityState.Nullable, info.ReadState);
+        Assert.Equal(NullabilityState.Nullable, info.WriteState);
+
+        MethodInfo privateValueTypeReturnMethod = type.GetMethod("BinarySearch", flags)!;
+        info = nullabilityContext.Create(privateValueTypeReturnMethod.ReturnParameter);
+        Assert.Equal(NullabilityState.NotNull, info.ReadState);
+        Assert.Equal(NullabilityState.NotNull, info.WriteState);
+
+        Type regexType = typeof(Regex);
+        FieldInfo protectedInternalNullableField = regexType.GetField("pattern", flags)!;
+        info = nullabilityContext.Create(protectedInternalNullableField);
+        Assert.Equal(NullabilityState.Nullable, info.ReadState);
+        Assert.Equal(NullabilityState.Nullable, info.WriteState);
+
+        privateNullableField = regexType.GetField("_runner", flags)!;
+        info = nullabilityContext.Create(privateNullableField);
+        Assert.Equal(NullabilityState.Unknown, info.ReadState);
+        Assert.Equal(NullabilityState.Unknown, info.WriteState);
+
+        ConstructorInfo privateConstructor = typeof(IndexOutOfRangeException)
+            .GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, new[] { typeof(SerializationInfo), typeof(StreamingContext) })!;
+        info = nullabilityContext.Create(privateConstructor.GetParameters()[0]);
+        Assert.Equal(NullabilityState.Unknown, info.WriteState);
+    }
+
+    public static IEnumerable<object[]> DifferentContextTestData()
+    {
+        yield return new object[] { "PropertyDisabled", NullabilityState.Unknown, NullabilityState.Unknown, typeof(string) };
+        yield return new object[] { "PropertyDisabledAllowNull", NullabilityState.Unknown, NullabilityState.Nullable, typeof(string) };
+        yield return new object[] { "PropertyDisabledMaybeNull", NullabilityState.Nullable, NullabilityState.Unknown, typeof(string) };
+        yield return new object[] { "PropertyEnabledAllowNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
+        yield return new object[] { "PropertyEnabledNotNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
+        yield return new object[] { "PropertyEnabledMaybeNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
+        yield return new object[] { "PropertyEnabledDisallowNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
+        yield return new object[] { "PropertyEnabledNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(string) };
+        yield return new object[] { "PropertyEnabledNonNullable", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
+    }
+    [Theory]
+    [MemberData(nameof(DifferentContextTestData))]
+    internal void NullabilityDifferentContextTest(string propertyName, NullabilityState readState, NullabilityState writeState, Type type)
+    {
+        Type noContext = typeof(TypeWithNoContext);
+        PropertyInfo property = noContext.GetProperty(propertyName, flags)!;
+        NullabilityInfo nullability = nullabilityContext.Create(property);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+
+        Type nullableContext = typeof(TypeWithNullableContext);
+        property = nullableContext.GetProperty(propertyName, flags)!;
+        nullability = nullabilityContext.Create(property);
+        Assert.Equal(readState, nullability.ReadState);
+        Assert.Equal(writeState, nullability.WriteState);
+        Assert.Equal(type, nullability.Type);
+    }
+
+    [Fact]
+    public void AttributedParametersTest()
+    {
+        Type type = typeof(TypeWithNullableContext);
+
+        // bool NotNullWhenParameter([DisallowNull] string? disallowNull, [NotNullWhen(true)] ref string? notNullWhen, Type? nullableType);
+        ParameterInfo[] notNullWhenParameters = type.GetMethod("NotNullWhenParameter", flags)!.GetParameters();
+        NullabilityInfo disallowNull = nullabilityContext.Create(notNullWhenParameters[0]);
+        NullabilityInfo notNullWhen = nullabilityContext.Create(notNullWhenParameters[1]);
+        Assert.Equal(NullabilityState.Nullable, disallowNull.ReadState);
+        Assert.Equal(NullabilityState.NotNull, disallowNull.WriteState);
+        Assert.Equal(NullabilityState.Nullable, notNullWhen.ReadState);
+        Assert.Equal(NullabilityState.Nullable, notNullWhen.WriteState);
+        Assert.Equal(NullabilityState.Nullable, nullabilityContext.Create(notNullWhenParameters[1]).ReadState);
+
+        // bool MaybeNullParameters([MaybeNull] string maybeNull, [MaybeNullWhen(false)] out string maybeNullWhen, Type? nullableType)
+        ParameterInfo[] maybeNullParameters = type.GetMethod("MaybeNullParameters", flags)!.GetParameters();
+        NullabilityInfo maybeNull = nullabilityContext.Create(maybeNullParameters[0]);
+        NullabilityInfo maybeNullWhen = nullabilityContext.Create(maybeNullParameters[1]);
+        Assert.Equal(NullabilityState.Nullable, maybeNull.ReadState);
+        Assert.Equal(NullabilityState.NotNull, maybeNull.WriteState);
+        Assert.Equal(NullabilityState.Nullable, maybeNullWhen.ReadState);
+        Assert.Equal(NullabilityState.NotNull, maybeNullWhen.WriteState);
+        Assert.Equal(NullabilityState.Nullable, nullabilityContext.Create(maybeNullParameters[1]).ReadState);
+
+        // string? AllowNullParameter([AllowNull] string allowNull, [NotNullIfNotNull(nameof(allowNull))] string? notNullIfNotNull)
+        ParameterInfo[] allowNullParameter = type.GetMethod("AllowNullParameter", flags)!.GetParameters();
+        NullabilityInfo allowNull = nullabilityContext.Create(allowNullParameter[0]);
+        NullabilityInfo notNullIfNotNull = nullabilityContext.Create(allowNullParameter[1]);
+        Assert.Equal(NullabilityState.NotNull, allowNull.ReadState);
+        Assert.Equal(NullabilityState.Nullable, allowNull.WriteState);
+        Assert.Equal(NullabilityState.Nullable, notNullIfNotNull.ReadState);
+        Assert.Equal(NullabilityState.Nullable, notNullIfNotNull.WriteState);
+        Assert.Equal(NullabilityState.Nullable, nullabilityContext.Create(allowNullParameter[1]).ReadState);
+
+        // [return: NotNullIfNotNull(nameof(nullable))] public string? NullableNotNullIfNotNullReturn(string? nullable, [NotNull] ref string? readNotNull)
+        ParameterInfo[] nullableNotNullIfNotNullReturn = type.GetMethod("NullableNotNullIfNotNullReturn", flags)!.GetParameters();
+        NullabilityInfo returnNotNullIfNotNull = nullabilityContext.Create(type.GetMethod("NullableNotNullIfNotNullReturn", flags)!.ReturnParameter);
+        NullabilityInfo readNotNull = nullabilityContext.Create(nullableNotNullIfNotNullReturn[1]);
+        Assert.Equal(NullabilityState.Nullable, returnNotNullIfNotNull.ReadState);
+        Assert.Equal(NullabilityState.Nullable, returnNotNullIfNotNull.WriteState);
+        Assert.Equal(NullabilityState.NotNull, readNotNull.ReadState);
+        Assert.Equal(NullabilityState.Nullable, readNotNull.WriteState);
+        Assert.Equal(NullabilityState.Nullable, nullabilityContext.Create(nullableNotNullIfNotNullReturn[0]).ReadState);
+
+        // public bool TryGetOutParameters(string id, [NotNullWhen(true)] out string? value, [MaybeNullWhen(false)] out string value2)
+        ParameterInfo[] tryGetOutParameters = type.GetMethod("TryGetOutParameters", flags)!.GetParameters();
+        NullabilityInfo notNullWhenParam = nullabilityContext.Create(tryGetOutParameters[1]);
+        NullabilityInfo maybeNullWhenParam = nullabilityContext.Create(tryGetOutParameters[2]);
+        Assert.Equal(NullabilityState.Nullable, notNullWhenParam.ReadState);
+        Assert.Equal(NullabilityState.Nullable, notNullWhenParam.WriteState);
+        Assert.Equal(NullabilityState.Nullable, maybeNullWhenParam.ReadState);
+        Assert.Equal(NullabilityState.NotNull, maybeNullWhenParam.WriteState);
+        Assert.Equal(NullabilityState.NotNull, nullabilityContext.Create(tryGetOutParameters[0]).ReadState);
+    }
+
+    public static IEnumerable<object[]> NestedGenericsCorrectOrderData()
+    {
+        yield return new object[] {
+                "MethodReturnsNonTupleNonTupleNullStringNullStringNullString",
+                new[] { NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.Nullable },
+                new[] { typeof(Tuple<Tuple<string, string>, string>), typeof(Tuple<string, string>), typeof(string), typeof(string), typeof(string) }
+            };
+        yield return new object[] {
+                "MethodReturnsNonTupleNonTupleNullStringNullStringNonString",
+                new[] { NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull },
+                new[] { typeof(Tuple<Tuple<string, string>, string>), typeof(Tuple<string, string>), typeof(string), typeof(string), typeof(string) }
+            };
+    }
+
+    [Theory]
+    [MemberData(nameof(NestedGenericsCorrectOrderData))]
+    internal void NestedGenericsCorrectOrderTest(string methodName, NullabilityState[] nullStates, Type[] types)
+    {
+        NullabilityInfo parentInfo = nullabilityContext.Create(typeof(TypeWithNotNullContext).GetMethod(methodName)!.ReturnParameter);
+        var dataIndex = 0;
+        Examine(parentInfo);
+        Assert.Equal(nullStates.Length, dataIndex);
+        Assert.Equal(types.Length, dataIndex);
+
+        void Examine(NullabilityInfo info)
+        {
+            Assert.Equal(types[dataIndex], info.Type);
+            Assert.Equal(nullStates[dataIndex++], info.ReadState);
+            for (var i = 0; i < info.GenericTypeArguments.Length; i++)
+            {
+                Examine(info.GenericTypeArguments[i]);
+            }
+        }
+    }
+
+    public static IEnumerable<object[]> NestedGenericsReturnParameterData()
+    {
+        // public IEnumerable<Tuple<(string name, object? value), int>?> MethodReturnsEnumerableNonTupleNonNonNullValueTupleNonNullNon() => null!;
+        yield return new object[] { "MethodReturnsEnumerableNonTupleNonNonNullValueTupleNonNullNon",
+                NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+
+        // public IEnumerable<Tuple<(string? name, object value)?, int>?>? MethodReturnsEnumerableNullTupleNullNonNullValueTupleNullNonNull() => null!;
+        yield return new object[] { "MethodReturnsEnumerableNullTupleNullNonNullValueTupleNullNonNull",
+                NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull };
+
+        // public IEnumerable<Tuple<Tuple<string, object?>, int>?> MethodReturnsEnumerableNonTupleNonNonNullTupleNonNullNon() => null!;
+        yield return new object[] { "MethodReturnsEnumerableNonTupleNonNonNullTupleNonNullNon",
+                NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+
+        // public IEnumerable<GenericStruct<Tuple<string, object?>?, int>?>? MethodReturnsEnumerableNullStructNullNonNonTupleNonNullNull() => null;
+        yield return new object[] { "MethodReturnsEnumerableNullStructNullNonNullTupleNonNullNull",
+                NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+
+        // public IEnumerable<Tuple<GenericStruct<string, object?>?, int>?>? MethodReturnsEnumerableNullTupleNullNonNullStructNonNullNull() => null;
+        yield return new object[] { "MethodReturnsEnumerableNullTupleNullNonNullStructNonNullNull",
+                NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+
+        // public IEnumerable<(GenericStruct<string, object?> str, int? count)> MethodReturnsEnumerableNonValueTupleNonNullNonTupleNonNullNon() => null!;
+        yield return new object[] { "MethodReturnsEnumerableNonValueTupleNonNullNonStructNonNullNon",
+                NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable };
+    }
+
+    [Theory]
+    [MemberData(nameof(NestedGenericsReturnParameterData))]
+    internal void NestedGenericsReturnParameterTest(string methodName, NullabilityState enumState, NullabilityState innerTupleState,
+        NullabilityState intState, NullabilityState outerTupleState, NullabilityState stringState, NullabilityState objectState)
+    {
+        NullabilityInfo enumerabeNullability = nullabilityContext.Create(typeof(TypeWithNotNullContext).GetMethod(methodName, flags)!.ReturnParameter);
+        Assert.Equal(enumState, enumerabeNullability.ReadState);
+        NullabilityInfo tupleNullability = enumerabeNullability.GenericTypeArguments[0];
+        Assert.Equal(outerTupleState, tupleNullability.ReadState);
+        Assert.Equal(innerTupleState, tupleNullability.GenericTypeArguments[0].ReadState);
+        Assert.Equal(intState, tupleNullability.GenericTypeArguments[1].ReadState);
+        NullabilityInfo valueTupleNullability = tupleNullability.GenericTypeArguments[0];
+        Assert.Equal(innerTupleState, valueTupleNullability.ReadState);
+        Assert.Equal(stringState, valueTupleNullability.GenericTypeArguments[0].ReadState);
+        Assert.Equal(objectState, valueTupleNullability.GenericTypeArguments[1].ReadState);
+    }
+
+    public static IEnumerable<object[]> RefReturnData()
+    {
+        yield return new object[] { "RefReturnUnknown", NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown };
+        // [return: MaybeNull] public ref string RefReturnMaybeNull([DisallowNull] ref string? id) 
+        yield return new object[] { "RefReturnMaybeNull", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull };
+        // public ref string RefReturnNotNullable([MaybeNull] ref string id)
+        yield return new object[] { "RefReturnNotNullable", NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull };
+        // [return: NotNull]public ref string? RefReturnNotNull([NotNull] ref string? id)
+        yield return new object[] { "RefReturnNotNull", NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+        // public ref string? RefReturnNullable([AllowNull] ref string id)
+        yield return new object[] { "RefReturnNullable", NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+    }
+
+    [Theory]
+    [MemberData(nameof(RefReturnData))]
+    internal void RefReturnTestTest(string methodName, NullabilityState retReadState, NullabilityState retWriteState, NullabilityState paramReadState, NullabilityState paramWriteState)
+    {
+        MethodInfo method = typeof(TypeWithNullableContext).GetMethod(methodName, flags)!;
+        NullabilityInfo returnNullability = nullabilityContext.Create(method.ReturnParameter);
+        NullabilityInfo paramNullability = nullabilityContext.Create(method.GetParameters()[0]);
+        Assert.Equal(retReadState, returnNullability.ReadState);
+        Assert.Equal(retWriteState, returnNullability.WriteState);
+        Assert.Equal(paramReadState, paramNullability.ReadState);
+        Assert.Equal(paramWriteState, paramNullability.WriteState);
+    }
+
+    public static IEnumerable<object[]> ValueTupleTestData()
+    {
+        // public (int, string) UnknownValueTuple; [0]
+        yield return new object[] { "UnknownValueTuple", NullabilityState.NotNull, NullabilityState.Unknown, NullabilityState.NotNull };
+        // public (string?, object) NullNonNonValueTuple; [0, 2, 1]
+        yield return new object[] { "Null_Non_Non_ValueTuple", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull };
+        // public (string?, object)? Null_Non_Null_ValueTuple; [0, 2, 1]
+        yield return new object[] { "Null_Non_Null_ValueTuple", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+        // public (int, int?)? Non_Null_Null_ValueTuple; [0]
+        yield return new object[] { "Non_Null_Null_ValueTuple", NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.Nullable };
+        // public (int, string) Non_Non_Non_ValueTuple; [0, 1]
+        yield return new object[] { "Non_Non_Non_ValueTuple", NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull };
+        // public (int, string?) Non_Null_Non_ValueTuple; [0, 2]
+        yield return new object[] { "Non_Null_Non_ValueTuple", NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull };
+    }
+
+    [Theory]
+    [MemberData(nameof(ValueTupleTestData))]
+    internal void TestValueTupleGenericTypeParameters(string fieldName, NullabilityState param1, NullabilityState param2, NullabilityState fieldState)
+    {
+        var tupleInfo = nullabilityContext.Create(testType.GetField(fieldName)!);
+
+        Assert.Equal(fieldState, tupleInfo.ReadState);
+        Assert.Equal(param1, tupleInfo.GenericTypeArguments[0].ReadState);
+        Assert.Equal(param2, tupleInfo.GenericTypeArguments[1].ReadState);
+    }
+
+    public static IEnumerable<object?[]> GenericInheritanceTestData()
+    {
+        yield return new object?[] { typeof(ListOfUnconstrained<string?>), NullabilityState.Nullable, null };
+        yield return new object?[] { typeof(ListUnconstrainedOfNullable<string>), NullabilityState.Nullable, null };
+        yield return new object?[] { typeof(ListUnconstrainedOfNullableOfObject<>), NullabilityState.NotNull, null };
+        yield return new object?[] { typeof(ListOfArrayOfNullableString), NullabilityState.NotNull, NullabilityState.Nullable };
+        yield return new object?[] { typeof(ListOfNotNull<ListOfNotNull<object>>), NullabilityState.NotNull, NullabilityState.NotNull };
+        yield return new object?[] { typeof(ListOfListOfObject<string?>), NullabilityState.NotNull, NullabilityState.NotNull };
+        yield return new object?[] { typeof(ListMultiGenericOfNotNull<object?, string, string?>), NullabilityState.NotNull, null };
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericInheritanceTestData))]
+    internal void TestGenericInheritance(Type listType, NullabilityState parameterState, NullabilityState? subState)
+    {
+        var addParameterInfo = nullabilityContext.Create(listType.GetMethod("Add")!.GetParameters()[0]);
+        Validate(addParameterInfo);
+
+        var copyToParameterInfo = nullabilityContext.Create(
+            listType.GetMethod("CopyTo", new[] { addParameterInfo.Type.MakeArrayType() })!
+                .GetParameters()[0]);
+        Assert.Equal(NullabilityState.NotNull, copyToParameterInfo.ReadState);
+        Assert.Equal(NullabilityState.NotNull, copyToParameterInfo.WriteState);
+        Assert.NotNull(copyToParameterInfo.ElementType);
+        Validate(copyToParameterInfo.ElementType!);
+
+        void Validate(NullabilityInfo info)
+        {
+            Assert.Equal(parameterState, info.ReadState);
+            Assert.Equal(parameterState, info.WriteState);
+            if (subState != null)
+            {
+                NullabilityInfo subInfo = info.ElementType ?? info.GenericTypeArguments[0];
+                Assert.Equal(subState, subInfo.ReadState);
+                Assert.Equal(subState, subInfo.WriteState);
+                Assert.True(info.GenericTypeArguments.Length <= 1);
+            }
+            else
+            {
+                Assert.Null(info.ElementType);
+                Assert.Empty(info.GenericTypeArguments);
+            }
+        }
+    }
+
+    [Fact]
+    public void TestDeeplyNestedGenericInheritance()
+    {
+        var copyToMethodInfo = nullabilityContext.Create(
+            typeof(ListOfTupleOfDictionaryOfStringNullableBoolIntNullableObject).GetMethod("CopyTo", new[] { typeof((Dictionary<string, bool?>, int, object?)[]) })!
+                .GetParameters()[0]);
+
+        Validate(copyToMethodInfo, typeof((Dictionary<string, bool?>, int, object?)[]), NullabilityState.NotNull);
+        Assert.NotNull(copyToMethodInfo.ElementType);
+
+        var tupleInfo = copyToMethodInfo.ElementType!;
+        Validate(tupleInfo, typeof((Dictionary<string, bool?>, int, object?)), NullabilityState.NotNull);
+
+        var dictionaryInfo = tupleInfo.GenericTypeArguments[0];
+        Validate(dictionaryInfo, typeof(Dictionary<string, bool?>), NullabilityState.NotNull);
+
+        var stringInfo = dictionaryInfo.GenericTypeArguments[0];
+        Validate(stringInfo, typeof(string), NullabilityState.NotNull);
+
+        var nullableBoolInfo = dictionaryInfo.GenericTypeArguments[1];
+        Validate(nullableBoolInfo, typeof(bool?), NullabilityState.Nullable);
+
+        var intInfo = tupleInfo.GenericTypeArguments[1];
+        Validate(intInfo, typeof(int), NullabilityState.NotNull);
+
+        var objectInfo = tupleInfo.GenericTypeArguments[2];
+        Validate(objectInfo, typeof(object), NullabilityState.Nullable);
+
+        void Validate(NullabilityInfo info, Type type, NullabilityState state)
+        {
+            Assert.Equal(type, info.Type);
+            Assert.Equal(state, info.ReadState);
+            Assert.Equal(state, info.WriteState);
+            Assert.Equal(type.IsGenericType && type.GetGenericTypeDefinition() != typeof(Nullable<>) ? type.GetGenericArguments().Length : 0, info.GenericTypeArguments.Length);
+            Assert.Equal(type.IsArray, info.ElementType is not null);
+        }
+    }
+
+    [Fact]
+    public void TestNestedGenericInheritanceWithMultipleParameters()
+    {
+        var item3Info = nullabilityContext.Create(typeof(DerivesFromTupleOfNestedGenerics).GetProperty("Item3")!);
+
+        Assert.Equal(typeof(IDisposable[]), item3Info.Type);
+        Assert.Equal(NullabilityState.Nullable, item3Info.ReadState);
+        Assert.Equal(NullabilityState.Unknown, item3Info.WriteState); // read-only property
+
+        Assert.Equal(NullabilityState.NotNull, item3Info.ElementType!.ReadState);
+        Assert.Equal(NullabilityState.NotNull, item3Info.ElementType.WriteState);
+    }
+
+    public static IEnumerable<object[]> TestNullabilityInfoCreationOnPropertiesWithNestedGenericTypeArgumentsData() => new[]
+    {
+            new object[] { typeof(TypeWithPropertiesNestingItsGenericTypeArgument<bool>), NullabilityState.NotNull },
+            new object[] { typeof(TypeWithPropertiesNestingItsGenericTypeArgument<bool?>), NullabilityState.Nullable },
+            new object[] { typeof(TypeWithPropertiesNestingItsGenericTypeArgument<object>), NullabilityState.Nullable },
+        };
+
+    [Theory]
+    [MemberData(nameof(TestNullabilityInfoCreationOnPropertiesWithNestedGenericTypeArgumentsData))]
+    internal void TestNullabilityInfoCreationOnPropertiesWithNestedGenericTypeArguments(Type type, NullabilityState expectedGenericArgumentNullability)
+    {
+        NullabilityInfo shallow1Info = nullabilityContext.Create(type.GetProperty("Shallow1")!);
+        NullabilityInfo deep1Info = nullabilityContext.Create(type.GetProperty("Deep1")!);
+        NullabilityInfo deep2Info = nullabilityContext.Create(type.GetProperty("Deep2")!);
+        NullabilityInfo deep3Info = nullabilityContext.Create(type.GetProperty("Deep3")!);
+        NullabilityInfo deep4Info = nullabilityContext.Create(type.GetProperty("Deep4")!);
+        NullabilityInfo deep5Info = nullabilityContext.Create(type.GetProperty("Deep5")!);
+
+        // public Tuple<T>? Shallow1 { get; set; }
+        NullabilityInfo info = shallow1Info;
+        Assert.Equal(1, info.GenericTypeArguments.Length);
+        Assert.Equal(expectedGenericArgumentNullability, info.GenericTypeArguments[0].ReadState);
+
+        // public Tuple<Tuple<T>>? Deep1 { get; set; }
+        info = deep1Info;
+        Assert.Equal(1, info.GenericTypeArguments.Length);
+        Assert.Equal(1, info.GenericTypeArguments[0].GenericTypeArguments.Length);
+        Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[0].ReadState);
+        Assert.Equal(expectedGenericArgumentNullability, info.GenericTypeArguments[0].GenericTypeArguments[0].ReadState);
+
+        // public Tuple<Tuple<T>, int>? Deep2 { get; set; }
+        info = deep2Info;
+        Assert.Equal(2, info.GenericTypeArguments.Length);
+        Assert.Equal(1, info.GenericTypeArguments[0].GenericTypeArguments.Length);
+        Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[0].ReadState);
+        Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[1].ReadState);
+        Assert.Equal(expectedGenericArgumentNullability, info.GenericTypeArguments[0].GenericTypeArguments[0].ReadState);
+
+        // public Tuple<int?, Tuple<T>>? Deep3 { get; set; }
+        info = deep3Info;
+        Assert.Equal(2, info.GenericTypeArguments.Length);
+        Assert.Equal(1, info.GenericTypeArguments[1].GenericTypeArguments.Length);
+        Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[0].ReadState);
+        Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[1].ReadState);
+        Assert.Equal(expectedGenericArgumentNullability, info.GenericTypeArguments[1].GenericTypeArguments[0].ReadState);
+
+        // public Tuple<int, int?, Tuple<T>>? Deep4 { get; set; }
+        info = deep4Info;
+        Assert.Equal(3, info.GenericTypeArguments.Length);
+        Assert.Equal(1, info.GenericTypeArguments[2].GenericTypeArguments.Length);
+        Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[0].ReadState);
+        Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[1].ReadState);
+        Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[2].ReadState);
+        Assert.Equal(expectedGenericArgumentNullability, info.GenericTypeArguments[2].GenericTypeArguments[0].ReadState);
+
+        // public Tuple<int, int, Tuple<T, int>?>? Deep5 { get; set; }
+        info = deep5Info;
+        Assert.Equal(3, info.GenericTypeArguments.Length);
+        Assert.Equal(2, info.GenericTypeArguments[2].GenericTypeArguments.Length);
+        Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[0].ReadState);
+        Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[1].ReadState);
+        Assert.Equal(NullabilityState.Nullable, info.GenericTypeArguments[2].ReadState);
+        Assert.Equal(expectedGenericArgumentNullability, info.GenericTypeArguments[2].GenericTypeArguments[0].ReadState);
+        Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[2].GenericTypeArguments[1].ReadState);
+    }
+
+    private static Type EnsureReflection([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type) => type;
+
+    public static IEnumerable<object[]> TestCtorParametersData() => new object[][]
+    {
+            [EnsureReflection(typeof(GenericTypeWithCtor<>)), NullabilityState.Nullable, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericTypeWithCtor<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericTypeWithCtor<int?>)), NullabilityState.Nullable, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericTypeWithCtor<object>)), NullabilityState.Nullable, NullabilityState.Nullable],
+
+            [EnsureReflection(typeof(GenericTypeWithCtor_Disallow<>)), NullabilityState.Nullable, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Disallow<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Disallow<int?>)), NullabilityState.Nullable, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Disallow<object>)), NullabilityState.Nullable, NullabilityState.NotNull],
+
+            [EnsureReflection(typeof(GenericTypeWithCtor_Maybe<>)), NullabilityState.Nullable, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Maybe<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Maybe<int?>)), NullabilityState.Nullable, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Maybe<object>)), NullabilityState.Nullable, NullabilityState.Nullable],
+
+            [EnsureReflection(typeof(GenericTypeWithCtor_Allow<>)), NullabilityState.Nullable, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Allow<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Allow<int?>)), NullabilityState.Nullable, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Allow<object>)), NullabilityState.Nullable, NullabilityState.Nullable],
+
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor<>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor<object>)), NullabilityState.NotNull, NullabilityState.NotNull],
+
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Disallow<>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Disallow<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Disallow<object>)), NullabilityState.NotNull, NullabilityState.NotNull],
+
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Maybe<>)), NullabilityState.Nullable, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Maybe<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Maybe<object>)), NullabilityState.Nullable, NullabilityState.NotNull],
+
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Allow<>)), NullabilityState.NotNull, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Allow<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Allow<object>)), NullabilityState.NotNull, NullabilityState.Nullable],
+    };
+
+    [Theory]
+    [MemberData(nameof(TestCtorParametersData))]
+    internal void TestCtorParameters([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type,
+        NullabilityState expectedRead, NullabilityState expectedWrite)
+    {
+        var ctx = new NullabilityInfoContext();
+
+        ParameterInfo param = type.GetConstructors()[0].GetParameters()[0];
+        NullabilityInfo info = ctx.Create(param);
+
+        Assert.Equal(expectedRead, info.ReadState);
+        Assert.Equal(expectedWrite, info.WriteState);
+    }
+
+    public static IEnumerable<object[]> TestMethodsWithOpenGenericParametersData()
+    {
+        const string MethodNullable = "GenericMethod";
+        const string MethodNonNullable = "GenericNotNullMethod";
+
+        return new object[][]
+        {
+                [EnsureReflection(typeof(ClassWithGenericMethods)), MethodNullable, NullabilityState.Nullable, NullabilityState.Nullable],
+                [EnsureReflection(typeof(ClassWithGenericMethods)), MethodNonNullable, NullabilityState.NotNull, NullabilityState.NotNull],
+                [EnsureReflection(typeof(ClassWithGenericMethods_Disallow)), MethodNullable, NullabilityState.Nullable, NullabilityState.NotNull],
+                [EnsureReflection(typeof(ClassWithGenericMethods_Disallow)), MethodNonNullable, NullabilityState.NotNull, NullabilityState.NotNull],
+                [EnsureReflection(typeof(ClassWithGenericMethods_Maybe)), MethodNullable, NullabilityState.Nullable, NullabilityState.Nullable],
+                [EnsureReflection(typeof(ClassWithGenericMethods_Maybe)), MethodNonNullable, NullabilityState.Nullable, NullabilityState.NotNull],
+                [EnsureReflection(typeof(ClassWithGenericMethods_Allow)), MethodNullable, NullabilityState.Nullable, NullabilityState.Nullable],
+                [EnsureReflection(typeof(ClassWithGenericMethods_Allow)), MethodNonNullable, NullabilityState.NotNull, NullabilityState.Nullable],
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(TestMethodsWithOpenGenericParametersData))]
+    internal void TestMethodsWithOpenGenericParameters([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type,
+        string methodName, NullabilityState expectedRead, NullabilityState expectedWrite)
+    {
+        var ctx = new NullabilityInfoContext();
+
+        MethodInfo method = type.GetMethod(methodName)!;
+
+        ParameterInfo paramInfo = method.GetParameters()[0];
+        NullabilityInfo info = ctx.Create(paramInfo);
+
+        Assert.Equal(expectedRead, info.ReadState);
+        Assert.Equal(expectedWrite, info.WriteState);
+    }
+
+    private delegate void GenericMethod<T>(T value);
+    private delegate void GenericMethodRef<T>([MaybeNull] out T value);
+    private delegate void GenericMethodDisallow<T>([DisallowNull] T value);
+    public static IEnumerable<object[]> TestMethodsWithGenericParametersData() => new object[][]
+    {
+            [(GenericMethod<int>)ClassWithGenericMethods.GenericMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethod<int?>)ClassWithGenericMethods.GenericMethod, NullabilityState.Nullable, NullabilityState.Nullable],
+            [(GenericMethod<object>)ClassWithGenericMethods.GenericMethod, NullabilityState.Nullable, NullabilityState.Nullable],
+
+            [(GenericMethod<int>)ClassWithGenericMethods.GenericNotNullMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethod<object>)ClassWithGenericMethods.GenericNotNullMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+
+            [(GenericMethodRef<int>)ClassWithGenericMethods_Maybe.GenericMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethodRef<int?>)ClassWithGenericMethods_Maybe.GenericMethod, NullabilityState.Nullable, NullabilityState.Nullable],
+            [(GenericMethodRef<object>)ClassWithGenericMethods_Maybe.GenericMethod, NullabilityState.Nullable, NullabilityState.Nullable],
+
+            [(GenericMethodRef<int>)ClassWithGenericMethods_Maybe.GenericNotNullMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethodRef<object>)ClassWithGenericMethods_Maybe.GenericNotNullMethod, NullabilityState.Nullable, NullabilityState.NotNull],
+
+            [(GenericMethod<int>)ClassWithGenericMethods_Allow.GenericMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethod<int?>)ClassWithGenericMethods_Allow.GenericMethod, NullabilityState.Nullable, NullabilityState.Nullable],
+            [(GenericMethod<object>)ClassWithGenericMethods_Allow.GenericMethod, NullabilityState.Nullable, NullabilityState.Nullable],
+
+            [(GenericMethod<int>)ClassWithGenericMethods_Allow.GenericNotNullMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethod<object>)ClassWithGenericMethods_Allow.GenericNotNullMethod, NullabilityState.NotNull, NullabilityState.Nullable],
+
+            // Specialized delegates are required due to CS8622
+
+            [(GenericMethodDisallow<int>)ClassWithGenericMethods_Disallow.GenericMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethodDisallow<int?>)ClassWithGenericMethods_Disallow.GenericMethod, NullabilityState.Nullable, NullabilityState.NotNull],
+            [(GenericMethodDisallow<object>)ClassWithGenericMethods_Disallow.GenericMethod, NullabilityState.Nullable, NullabilityState.NotNull],
+
+            [(GenericMethodDisallow<int>)ClassWithGenericMethods_Disallow.GenericNotNullMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethodDisallow<object>)ClassWithGenericMethods_Disallow.GenericNotNullMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+    };
+
+    [Theory]
+    [MemberData(nameof(TestMethodsWithGenericParametersData))]
+    internal void TestMethodsWithGenericParameters(Delegate @delegate, NullabilityState expectedRead, NullabilityState expectedWrite)
+    {
+        var ctx = new NullabilityInfoContext();
+
+        MethodInfo method = @delegate.Method;
+
+        ParameterInfo paramInfo = method.GetParameters()[0];
+        NullabilityInfo info = ctx.Create(paramInfo);
+
+        Assert.Equal(expectedRead, info.ReadState);
+        Assert.Equal(expectedWrite, info.WriteState);
+    }
+}
+
+#pragma warning disable CS0649, CS0067, CS0414
+public class TypeWithNullableContext
+{
+#nullable disable
+    [AllowNull] public string PropertyDisabledAllowNull { get; set; }
+    [MaybeNull] public string PropertyDisabledMaybeNull { get; set; }
+    public string PropertyDisabled { get; set; }
+    public ref string RefReturnUnknown(ref string id) { return ref id; }
+#nullable enable
+    [AllowNull] public string PropertyEnabledAllowNull { get; set; }
+    [NotNull] public string? PropertyEnabledNotNull { get; set; } = null!;
+    [DisallowNull] public string? PropertyEnabledDisallowNull { get; set; } = null!;
+    [MaybeNull] public string PropertyEnabledMaybeNull { get; set; }
+    public string? PropertyEnabledNullable { get; set; }
+    public string PropertyEnabledNonNullable { get; set; } = null!;
+    bool NotNullWhenParameter([DisallowNull] string? disallowNull, [NotNullWhen(true)] ref string? notNullWhen, Type? nullableType) { return false; }
+    public bool MaybeNullParameters([MaybeNull] string maybeNull, [MaybeNullWhen(false)] out string maybeNullWhen, Type? nullableType) { maybeNullWhen = null; return false; }
+    public string? AllowNullParameter([AllowNull] string allowNull, [NotNullIfNotNull(nameof(allowNull))] string? notNullIfNotNull) { return null; }
+    [return: NotNullIfNotNull(nameof(nullable))] public string? NullableNotNullIfNotNullReturn(string? nullable, [NotNull] ref string? readNotNull) { readNotNull = string.Empty; return null!; }
+    public ref string? RefReturnNullable([AllowNull] ref string id) { return ref id!; }
+    [return: MaybeNull] public ref string RefReturnMaybeNull([DisallowNull] ref string? id) { return ref id; }
+    [return: NotNull] public ref string? RefReturnNotNull([NotNull] ref string? id) { id = string.Empty; return ref id!; }
+    public ref string RefReturnNotNullable([MaybeNull] ref string id) { return ref id; }
+    public bool TryGetOutParameters(string id, [NotNullWhen(true)] out string? value, [MaybeNullWhen(false)] out string value2) { value = null; value2 = null; return false; }
+    public IEnumerable<Tuple<(string name, object? value), object>?> MethodReturnsEnumerableNonTupleNonNonNullValueTupleNonNullNon() => null!;
+}
+
+public class TypeWithNoContext
+{
+#nullable disable
+    [AllowNull] public string PropertyDisabledAllowNull { get; set; }
+    [MaybeNull] public string PropertyDisabledMaybeNull { get; set; }
+    public string PropertyDisabled { get; set; }
+#nullable enable
+    [AllowNull] public string PropertyEnabledAllowNull { get; set; }
+    [NotNull] public string? PropertyEnabledNotNull { get; set; } = null!;
+    [DisallowNull] public string? PropertyEnabledDisallowNull { get; set; } = null!;
+    [MaybeNull] public string PropertyEnabledMaybeNull { get; set; }
+    public string? PropertyEnabledNullable { get; set; }
+    public string PropertyEnabledNonNullable { get; set; } = null!;
+#nullable disable
+}
+
+public class TypeWithNotNullContext
+{
+    public string PropertyUnknown { get; set; }
+    short PropertyValueTypeUnknown { get; set; }
+    public string[] PropertyArrayUnknown { get; set; }
+    private string[][] PropertyJaggedArrayUnknown { get; set; }
+    protected Tuple<string, string, string> PropertyTupleUnknown { get; set; }
+    protected internal IDictionary<Type, string[]> PropertyDictionaryUnknown { get; set; }
+
+    public (int, string) UnknownValueTuple;
+    internal TypeWithNotNullContext FieldUnknown;
+    public int FieldValueTypeUnknown;
+
+    public event EventHandler EventUnknown;
+    public string[] MethodReturnsUnknown() => null!;
+    public void MethodParametersUnknown(string s, IDictionary<Type, string[]> dict) { }
+#nullable enable
+    public TypeWithNotNullContext? PropertyNullable { get; set; }
+    public TypeWithNotNullContext? PropertyNullableReadOnly { get; }
+    private SystemReflectionNullabilityInfoContextTests PropertyNonNullable { get; set; } = null!;
+    internal float PropertyValueType { get; set; }
+    protected long? PropertyValueTypeNullable { get; set; }
+    [DisallowNull] public int? PropertyValueTypeDisallowNull { get; set; }
+    [NotNull] protected int? PropertyValueTypeNotNull { get; set; }
+    [MaybeNull] public byte PropertyValueTypeMaybeNull { get; set; }
+    [AllowNull] public byte PropertyValueTypeAllowNull { get; set; }
+    [DisallowNull] public string? PropertyDisallowNull { get; set; }
+    [AllowNull] public string PropertyAllowNull { get; set; }
+    [NotNull] public string? PropertyNotNull { get; set; }
+    [MaybeNull] public string PropertyMaybeNull { get; set; }
+    // only DisallowNull matters
+    [AllowNull, DisallowNull] public string PropertyAllowNull2 { get; set; }
+    // only AllowNull matters
+    [AllowNull, DisallowNull] public string? PropertyDisallowNull2 { get; set; }
+    // only NotNull matters
+    [NotNull, MaybeNull] public string? PropertyNotNull2 { get; set; }
+    // only NotNull matters
+    [NotNull, MaybeNull] public string PropertyMaybeNull2 { get; set; }
+    [DisallowNull] public string? this[int i] { get => null; set { } }
+    private protected string?[]?[]? PropertyJaggedArrayNullNullNull { get; set; }
+    public static string?[]?[] PropertyJaggedArrayNullNullNon { get; set; } = null!;
+    public string?[][]? PropertyJaggedArrayNullNonNull { get; set; }
+    public static string[]?[]? PropertyJaggedArrayNonNullNull { get; set; }
+    public string?[][] PropertyJaggedArrayNullNonNon { get; set; } = null!;
+    private static string[][]? PropertyJaggedArrayNonNonNull { get; set; }
+    public string?[]? PropertyArrayNullNull { get; set; }
+    static string?[] PropertyArrayNullNon { get; set; } = null!;
+    public string[]? PropertyArrayNonNull { get; } = null;
+    public string[] PropertyArrayNonNon { get; set; } = null!;
+    public Tuple<string?, string?, string?>? PropertyTupleNullNullNullNull { get; set; }
+    public Tuple<string, string?, string> PropertyTupleNonNullNonNon { get; set; } = null!;
+    internal Tuple<string?, string, string?>? PropertyTupleNullNonNullNull { get; set; }
+    public Tuple<string, string?, string>? PropertyTupleNonNullNonNull { get; set; }
+    protected Tuple<string, string, string> PropertyTupleNonNonNonNon { get; set; } = null!;
+    public IDictionary<Type?, string?[]?> PropertyDictionaryNullNullNullNon { get; set; } = null!;
+    public IDictionary<Type, string?[]>? PropertyDictionaryNonNullNonNull { get; set; }
+    IDictionary<Type?, string[]>? PropertyDictionaryNullNonNonNull { get; set; }
+    public IDictionary<Type, string?[]> PropertyDictionaryNonNullNonNon { get; set; } = null!;
+    private IDictionary<Type, string[]>? PropertyDictionaryNonNonNonNull { get; set; }
+    public IDictionary<Type, string[]> PropertyDictionaryNonNonNonNon { get; set; } = null!;
+
+    public (string?, object) Null_Non_Non_ValueTuple;
+    public (string?, object)? Null_Non_Null_ValueTuple;
+    public (int, int?)? Non_Null_Null_ValueTuple;
+    public (int, string) Non_Non_Non_ValueTuple;
+    public (int, string?) Non_Null_Non_ValueTuple;
+    private const string? FieldNullable = null;
+    protected static SystemReflectionNullabilityInfoContextTests FieldNonNullable = null!;
+    public static double FieldValueTypeNotNull;
+    public readonly int? FieldValueTypeNullable;
+    [DisallowNull] public string? FieldDisallowNull;
+    [AllowNull] public string FieldAllowNull;
+    [NotNull] string? FieldNotNull = null;
+    [MaybeNull] public string FieldMaybeNull;
+    [AllowNull, DisallowNull] public string FieldAllowNull2;
+    [AllowNull, DisallowNull] public string? FieldDisallowNull2;
+    [NotNull, MaybeNull] internal string? FieldNotNull2;
+    [NotNull, MaybeNull] public string FieldMaybeNull2;
+
+    public event EventHandler? EventNullable;
+    public event EventHandler EventNotNull = null!;
+    public string?[] MethodReturnsNullNon() => null!;
+    public string?[]? MethodReturnsNullNull() => null;
+    public string[]? MethodReturnsNonNull() => null;
+    [return: NotNull, MaybeNull] public string[]? MethodReturnsNonNotNull() => null!; // only NotNull is applicable
+    [return: MaybeNull] public string[] MethodReturnsNonMaybeNull() => null;
+    public string[] MethodReturnsNonNon() => null!;
+    public Tuple<string?, string>? MethodReturnsTupleNullNonNull() => null;
+    public Tuple<string?, int> MethodReturnsTupleNullNonNot() => null!;
+    public (int?, string)? MethodReturnsValueTupleNullNonNull() => null;
+    public (string?, string) MethodReturnsValueTupleNullNonNon() => (null, string.Empty);
+    public IEnumerable<Tuple<(string name, object? value), int>?> MethodReturnsEnumerableNonTupleNonNonNullValueTupleNonNullNon() => null!;
+    public IEnumerable<Tuple<(string? name, object value)?, int>?>? MethodReturnsEnumerableNullTupleNullNonNullValueTupleNullNonNull() => null!;
+    public IEnumerable<Tuple<Tuple<string, object?>, int>?> MethodReturnsEnumerableNonTupleNonNonNullTupleNonNullNon() => null!;
+    public IEnumerable<GenericStruct<Tuple<string, object?>?, int>?>? MethodReturnsEnumerableNullStructNullNonNullTupleNonNullNull() => null;
+    public IEnumerable<Tuple<GenericStruct<string, object?>?, int>?>? MethodReturnsEnumerableNullTupleNullNonNullStructNonNullNull() => null;
+    public IEnumerable<(GenericStruct<string, object?> str, int? count)> MethodReturnsEnumerableNonValueTupleNonNullNonStructNonNullNon() => null!;
+    public Tuple<Tuple<string?, string?>, string?> MethodReturnsNonTupleNonTupleNullStringNullStringNullString() => null!;
+    public Tuple<Tuple<string?, string?>, string> MethodReturnsNonTupleNonTupleNullStringNullStringNonString() => null!;
+    public void MethodNullNonNullNonNon(string? s, IDictionary<Type, string?[]> dict) { }
+    public void MethodNonNullNonNullNotNull(string s, [NotNull] IDictionary<Type, string[]?>? dict) { dict = new Dictionary<Type, string[]?>(); }
+    public void MethodNullNonNullNullNon(string? s, IDictionary<Type, string?[]?> dict) { }
+    public void MethodAllowNullNonNonNonNull([AllowNull] string s, IDictionary<Type, string[]>? dict) { }
+
+    public ref readonly int? MethodWithByRefs(out int? a, out string b, ref object? c, ref Type d, in decimal? e, in ICloneable f) =>
+        throw new NotImplementedException();
+    public ref Tuple<int?, string, IDisposable?> MethodWithGenericByRefs(
+        out KeyValuePair<string?, object> a,
+        ref Tuple<Type?, decimal>? b,
+        in KeyValuePair<ICloneable, IFormatProvider?>? c) =>
+        throw new NotImplementedException();
+    public ref T ConstrainedGenericMethodWithByRef<T>(out T[] array) where T : class? => throw new NotImplementedException();
+    public unsafe void MethodWithPointers(int* a, int?* b) { }
+    public unsafe void GenericMethodWithPointers<T>(T* a, T?* b) where T : unmanaged { }
+}
+
+public struct GenericStruct<T, Y> { }
+
+internal class GenericTest<T>
+{
+#nullable disable
+    public T PropertyUnknown { get; set; }
+    protected T[] PropertyArrayUnknown { get; set; }
+    public Tuple<T, string, TypeWithNotNullContext> PropertyTupleUnknown { get; set; }
+    private IDictionary<Type, T[]> PropertyDictionaryUnknown { get; set; }
+    public T FieldUnknown;
+    public T MethodReturnsUnknown() => default!;
+    public void MethodParametersUnknown(T s, IDictionary<Type, T> dict) { }
+#nullable enable
+
+    public T PropertyNonNullable { get; set; } = default!;
+    public T? PropertyNullable { get; set; }
+    [DisallowNull] public T PropertyDisallowNull { get; set; } = default!;
+    [NotNull] public T PropertyNotNull { get; set; } = default!;
+    [MaybeNull] public T PropertyMaybeNull { get; set; }
+    [AllowNull] public T PropertyAllowNull { get; set; }
+    internal T?[]? PropertyArrayNullNull { get; set; }
+    public T?[] PropertyArrayNullNon { get; set; } = null!;
+    T[]? PropertyArrayNonNull { get; set; }
+    public T[] PropertyArrayNonNon { get; set; } = null!;
+    public Tuple<T?, string?, string?>? PropertyTupleNullNullNullNull { get; set; }
+    public Tuple<T, T?, string> PropertyTupleNonNullNonNon { get; set; } = null!;
+    Tuple<string?, T, T?>? PropertyTupleNullNonNullNull { get; set; }
+    public Tuple<T, int?, string>? PropertyTupleNonNullNonNull { get; set; }
+    public Tuple<int, string, T> PropertyTupleNonNonNonNon { get; set; } = null!;
+    private IDictionary<T?, string?[]?> PropertyDictionaryNullNullNullNon { get; set; } = null!;
+    static IDictionary<Type, T?[]>? PropertyDictionaryNonNullNonNull { get; set; }
+    public static IDictionary<T?, T[]>? PropertyDictionaryNullNonNonNull { get; set; }
+    public IDictionary<Type, T?[]> PropertyDictionaryNonNullNonNon { get; set; } = null!;
+    protected IDictionary<T, T[]>? PropertyDictionaryNonNonNonNull { get; set; }
+    public IDictionary<T, int[]> PropertyDictionaryNonNonNonNon { get; set; } = null!;
+
+    static T? FieldNullable = default;
+    public T FieldNonNullable = default!;
+    [DisallowNull] public T? FieldDisallowNull;
+    [AllowNull] protected T FieldAllowNull;
+    [NotNull] public T? FieldNotNull = default;
+    [MaybeNull] protected internal T FieldMaybeNull = default!;
+    public List<T> FieldListOfT = default!;
+    public Dictionary<string, T> FieldDictionaryStringToT = default!;
+
+    public T MethodReturnsGeneric() => default!;
+    public T? MethodReturnsNullGeneric() => default;
+    [return: NotNull] public T MethodReturnsGenericNotNull() => default!;
+    [return: MaybeNull] public T MethodReturnsGenericMaybeNull() => default;
+    public List<T?> MethodNonNullListNullGeneric() => null!;
+    public List<T>? MethodNullListNonNullGeneric() => null;
+    public void MethodArgsNullGenericNullDictValueGeneric(T? s, IDictionary<Type, T>? dict) { }
+    public void MethodArgsGenericDictValueNullGeneric(T s, IDictionary<string, T?> dict) { }
+
+    public ref T? this[in T a, in List<T?> b] => throw new NotImplementedException();
+}
+
+internal class GenericTestConstrainedNotNull<T> where T : notnull
+{
+#nullable disable
+    public T FieldUnknown;
+    public T PropertyUnknown { get; set; }
+#nullable enable
+
+    public T FieldNullableEnabled = default!;
+    public T? FieldNullable;
+    public T PropertyNullableEnabled { get; set; } = default!;
+    public T? PropertyNullable { get; set; } = default!;
+}
+
+internal class GenericTestConstrainedStruct<T> where T : struct
+{
+#nullable disable
+    public T FieldUnknown;
+    public T PropertyUnknown { get; set; }
+#nullable enable
+
+    public T FieldNullableEnabled;
+    public T? FieldNullable;
+    public T PropertyNullableEnabled { get; set; }
+    public T? PropertyNullable { get; set; }
+}
+
+public class ListOfUnconstrained<T> : List<T> { }
+
+public class ListUnconstrainedOfNullable<T> : ListOfUnconstrained<T> where T : class? { }
+
+public class ListUnconstrainedOfNullableOfObject<T> : ListUnconstrainedOfNullable<object> { }
+
+public class ListOfArrayOfNullableString : List<string?[]> { }
+
+public class ListOfNotNull<T> : List<T> where T : notnull { }
+
+public class ListOfListOfObject<T> : List<List<object>> { }
+
+public class ListMultiGenericOfNotNull<T, U, V> : List<U>
+    where T : class?
+    where U : class
+    where V : class?
+{
+}
+
+public class ListOfTupleOfDictionaryOfStringNullableBoolIntNullableObject : List<(Dictionary<string, bool?>, int, object?)> { }
+
+public class DerivesFromTupleOfNestedGenerics : Tuple<List<string[]>, Dictionary<object[], List<object>>, IDisposable[]?>
+{
+    public DerivesFromTupleOfNestedGenerics(List<string[]> item1, Dictionary<object[], List<object>> item2, IDisposable[]? item3)
+        : base(item1, item2, item3)
+    {
+    }
+}
+
+public class TypeWithPropertiesNestingItsGenericTypeArgument<T>
+{
+    public Tuple<T>? Shallow1 { get; set; }
+    public Tuple<Tuple<T>>? Deep1 { get; set; }
+    public Tuple<Tuple<T>, int>? Deep2 { get; set; }
+    public Tuple<int?, Tuple<T>>? Deep3 { get; set; }
+    public Tuple<int, int?, Tuple<T?>>? Deep4 { get; set; }
+    public Tuple<int, int, Tuple<T, int>?>? Deep5 { get; set; }
+}
+
+public class GenericTypeWithCtor<T>
+{
+    public GenericTypeWithCtor(T value) { }
+}
+public class GenericTypeWithCtor_Disallow<T>
+{
+    public GenericTypeWithCtor_Disallow([DisallowNull] T value) { }
+}
+public class GenericTypeWithCtor_Maybe<T>
+{
+    public GenericTypeWithCtor_Maybe([MaybeNull] out T value) { value = default; }
+}
+public class GenericTypeWithCtor_Allow<T>
+{
+    public GenericTypeWithCtor_Allow([AllowNull] T value) { }
+}
+public class GenericNonNullableTypeWithCtor<T> where T : notnull
+{
+    public GenericNonNullableTypeWithCtor(T value) { }
+}
+public class GenericNonNullableTypeWithCtor_Disallow<T> where T : notnull
+{
+    public GenericNonNullableTypeWithCtor_Disallow([DisallowNull] T value) { }
+}
+public class GenericNonNullableTypeWithCtor_Maybe<T> where T : notnull
+{
+    public GenericNonNullableTypeWithCtor_Maybe([MaybeNull] out T value) { value = default; }
+}
+public class GenericNonNullableTypeWithCtor_Allow<T> where T : notnull
+{
+    public GenericNonNullableTypeWithCtor_Allow([AllowNull] T value) { }
+}
+public class ClassWithGenericMethods
+{
+    public static void GenericMethod<T>(T value) => throw new Exception();
+    public static void GenericNotNullMethod<T>(T value) where T : notnull => throw new Exception();
+}
+public class ClassWithGenericMethods_Disallow
+{
+    public static void GenericMethod<T>([DisallowNull] T value) => throw new Exception();
+    public static void GenericNotNullMethod<T>([DisallowNull] T value) where T : notnull => throw new Exception();
+}
+public class ClassWithGenericMethods_Maybe
+{
+    public static void GenericMethod<T>([MaybeNull] out T value) => throw new Exception();
+    public static void GenericNotNullMethod<T>([MaybeNull] out T value) where T : notnull => throw new Exception();
+}
+public class ClassWithGenericMethods_Allow
+{
+    public static void GenericMethod<T>([AllowNull] T value) => throw new Exception();
+    public static void GenericNotNullMethod<T>([AllowNull] T value) where T : notnull => throw new Exception();
+}

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The filtering logic works as follows:
 
 <!-- begin_polyfills -->
 
-### Types (71)
+### Types (74)
 
 - `System.Buffers.SearchValues`
 - `System.Buffers.SearchValues<T> where T : System.IEquatable<T>?`
@@ -89,6 +89,9 @@ The filtering logic works as follows:
 - `System.Index`
 - `System.Net.Http.ReadOnlyMemoryContent`
 - `System.Range`
+- `System.Reflection.NullabilityInfo`
+- `System.Reflection.NullabilityInfoContext`
+- `System.Reflection.NullabilityState`
 - `System.Runtime.CompilerServices.AsyncMethodBuilderAttribute`
 - `System.Runtime.CompilerServices.CallerArgumentExpressionAttribute`
 - `System.Runtime.CompilerServices.CollectionBuilderAttribute`


### PR DESCRIPTION
# What

Add support for the `System.Reflection.NullabilityInfo`, `NullabilityInfoContext`, and `NullabilityState` types.

# Changes

- Added `System.Reflection.NullabilityInfoContext` with supporting classes.
- Added tests from dotnet/runtime to ensure comparable behaviour.

# Note

Had to remove [NullablePublicOnlyOtherTypesTest() -> publicGetPrivateSetNullableProperty](https://github.com/dotnet/runtime/blob/fc46e69833252336a0ac9e147631952d64e04305/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/NullabilityInfoContextTests.cs#L915) test due to a dependency on `System.IO.Enumeration.FileSystemEntry`, that would require a lot of additional polyfills. Could not find any viable substitue in the dotnet/runtime source.