### PR TITLE
Optimize string.IndexOf(char, StringComparison)

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.String.IndexOf(System.Char,System.StringComparison).cs
+++ b/Meziantou.Polyfill.Editor/M;System.String.IndexOf(System.Char,System.StringComparison).cs
@@ -2,6 +2,7 @@
 {
     public static int IndexOf(this string target, char value, System.StringComparison comparisonType)
     {
+        if (comparisonType == System.StringComparison.Ordinal) return target.IndexOf(value);
         return target.IndexOf(value.ToString(), comparisonType);
     }
 }


### PR DESCRIPTION
Special case where `StringComparison` is `Ordinal` avoids creating a string object on the heap. Note that `sting.IndexOf` is used from polyfill `string.Contains`, so the change affects that one too.