### PR TITLE
Add polyfill for string.Create<TState> method

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.String.Create``1(System.Int32,``0,System.Buffers.SpanAction{System.Char,``0}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.String.Create``1(System.Int32,``0,System.Buffers.SpanAction{System.Char,``0}).cs
@@ -1,0 +1,30 @@
+using System;
+using System.Buffers;
+
+static partial class PolyfillExtensions
+{
+    extension(string)
+    {
+        public static string Create<TState>(int length, TState state, SpanAction<char, TState> action)
+        {
+            if (action is null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            if (length == 0)
+            {
+                return string.Empty;
+            }
+
+            if (length < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            Span<char> span = length <= 256 ? stackalloc char[length] : new char[length];
+            action(span, state);
+            return span.ToString();
+        }
+    }
+}

--- a/Meziantou.Polyfill.Editor/T;System.Buffers.SpanAction`2.cs
+++ b/Meziantou.Polyfill.Editor/T;System.Buffers.SpanAction`2.cs
@@ -1,0 +1,4 @@
+namespace System.Buffers
+{
+    internal delegate void SpanAction<T, in TArg>(global::System.Span<T> span, TArg arg);
+}

--- a/Meziantou.Polyfill.Editor/T;System.Buffers.SpanAction`2.cs
+++ b/Meziantou.Polyfill.Editor/T;System.Buffers.SpanAction`2.cs
@@ -1,4 +1,9 @@
 namespace System.Buffers
 {
+#if MEZIANTOU_POLYFILL_SUPPORT_ALLOWS_REF_STRUCT
+    internal delegate void SpanAction<T, in TArg>(global::System.Span<T> span, TArg arg)
+        where TArg : allows ref struct;
+#else
     internal delegate void SpanAction<T, in TArg>(global::System.Span<T> span, TArg arg);
+#endif
 }

--- a/Meziantou.Polyfill.Generator/PolyfillData.cs
+++ b/Meziantou.Polyfill.Generator/PolyfillData.cs
@@ -9,6 +9,7 @@ internal sealed partial class PolyfillData
 {
     private static readonly string[] PotentialRequiredTypes =
     [
+        "System.Buffers.SpanAction`2",
         "System.Collections.Generic.IAsyncEnumerable`1",
         "System.Collections.Generic.IAsyncEnumerable`1",
         "System.Collections.Generic.IAsyncEnumerator`1",
@@ -109,6 +110,20 @@ internal sealed partial class PolyfillData
                     return true;
 
                 return IsExposed(symbol.ContainingSymbol);
+            }
+        }
+
+        foreach (var @delegate in root.DescendantNodes().OfType<DelegateDeclarationSyntax>())
+        {
+            var symbol = semanticModel.GetDeclaredSymbol(@delegate)!;
+            var invokeMethod = symbol.DelegateInvokeMethod;
+            if (invokeMethod is null)
+                continue;
+
+            requiredTypes.Add(invokeMethod.ReturnType);
+            foreach (var param in invokeMethod.Parameters.Select(p => p.Type))
+            {
+                requiredTypes.Add(param);
             }
         }
 

--- a/Meziantou.Polyfill.Generator/Program.cs
+++ b/Meziantou.Polyfill.Generator/Program.cs
@@ -151,6 +151,7 @@ async Task GenerateMembers()
     }
 
     sb.AppendLine($"private readonly PolyfillOptions _options;");
+    sb.AppendLine($"private readonly bool _supportAllowsRefStruct;");
     sb.AppendLine($"private readonly bool _supportExtensions;");
     sb.AppendLine($"private readonly bool _supportUnsafe;");
     sb.AppendLine($"private readonly string _extraDefines;");
@@ -163,7 +164,10 @@ async Task GenerateMembers()
     sb.AppendLine("public Members(Compilation compilation, PolyfillOptions options)");
     sb.AppendLine("{");
     sb.AppendLine("    _options = options;");
-    sb.AppendLine("    _supportExtensions = Enum.IsDefined(typeof(LanguageVersion), 1400) && compilation.SyntaxTrees.FirstOrDefault()?.Options is CSharpParseOptions parseOptions && parseOptions.LanguageVersion >= (LanguageVersion)1400;");
+    sb.AppendLine("    var languageVersion = compilation.SyntaxTrees.FirstOrDefault()?.Options is CSharpParseOptions parseOptions ? parseOptions.LanguageVersion : LanguageVersion.Default;");
+    sb.AppendLine("    var runtimeFeature = compilation.GetSpecialType(SpecialType.System_Object).ContainingAssembly.GetTypeByMetadataName(\"System.Runtime.CompilerServices.RuntimeFeature\");");
+    sb.AppendLine("    _supportAllowsRefStruct = Enum.IsDefined(typeof(LanguageVersion), 1300) && languageVersion >= (LanguageVersion)1300 && (runtimeFeature?.GetMembers(\"ByRefLikeGenerics\").Length ?? 0) > 0;");
+    sb.AppendLine("    _supportExtensions = Enum.IsDefined(typeof(LanguageVersion), 1400) && languageVersion >= (LanguageVersion)1400;");
     sb.AppendLine("    _supportUnsafe = compilation.Options is CSharpCompilationOptions compilationOptions && compilationOptions.AllowUnsafe;");
 
     foreach (var requiredType in requiredTypes)
@@ -172,6 +176,7 @@ async Task GenerateMembers()
     }
 
     sb.AppendLine($"    _extraDefines = \"\";");
+    sb.AppendLine("    if (_supportAllowsRefStruct) _extraDefines += \"#define MEZIANTOU_POLYFILL_SUPPORT_ALLOWS_REF_STRUCT\\n\";");
     sb.AppendLine("    if (_supportUnsafe) _extraDefines += \"#define MEZIANTOU_POLYFILL_SUPPORT_UNSAFE\\n\";");
     foreach (var requiredType in requiredTypes)
     {

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -2393,6 +2393,14 @@
       "net9.0",
       "net10.0"
     ],
+    "M:System.String.Create\u0060\u00601(System.Int32,\u0060\u00600,System.Buffers.SpanAction{System.Char,\u0060\u00600})": [
+      "netstandard2.1",
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
     "M:System.String.EndsWith(System.Char)": [
       "netstandard2.1",
       "net462",
@@ -3179,6 +3187,14 @@
       "net10.0"
     ],
     "T:System.Buffers.SequenceReader\u00601": [
+      "netstandard2.1",
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0"
+    ],
+    "T:System.Buffers.SpanAction\u00602": [
       "netstandard2.1",
       "net6.0",
       "net7.0",

--- a/Meziantou.Polyfill.SourceGenerator.Tests/UnitTest1.cs
+++ b/Meziantou.Polyfill.SourceGenerator.Tests/UnitTest1.cs
@@ -199,6 +199,53 @@ public class UnitTest1
         };
     }
 
+    [Theory]
+    [MemberData(nameof(GetRuntimeWithoutByRefLikeGenericSupportLanguageVersions))]
+    public async Task SpanAction_AllowsRefStructConstraint_IsNotGenerated_WhenRuntimeDoesNotSupportByRefLikeGenerics(LanguageVersion languageVersion)
+    {
+        var assemblies = await NuGetHelpers.GetNuGetReferences("NETStandard.Library", "2.0.3", "build/");
+        var result = GenerateFiles(
+            """
+            namespace System
+            {
+                public readonly ref struct Span<T>
+                {
+                }
+            }
+            """,
+            assemblyLocations: assemblies,
+            includedPolyfills: "T:System.Buffers.SpanAction`2",
+            languageVersion: languageVersion);
+
+        var content = GetGeneratedFileContent(result.GeneratorResult, "T_System.Buffers.SpanAction`2.g.cs");
+        Assert.DoesNotContain("#define MEZIANTOU_POLYFILL_SUPPORT_ALLOWS_REF_STRUCT", content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AllowsRefStructDefine_IsGenerated_WhenLanguageAndRuntimeSupportByRefLikeGenerics()
+    {
+        var assemblies = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "9.0.0", "ref/net9.0/");
+        var result = GenerateFiles(
+            "",
+            assemblyLocations: assemblies,
+            includedPolyfills: "P:System.Net.Http.HttpMethod.Query",
+            languageVersion: LanguageVersion.CSharp14);
+
+        var content = GetGeneratedFileContent(result.GeneratorResult, "P_System.Net.Http.HttpMethod.Query.g.cs");
+        Assert.Contains("#define MEZIANTOU_POLYFILL_SUPPORT_ALLOWS_REF_STRUCT", content, StringComparison.Ordinal);
+    }
+
+    public static TheoryData<LanguageVersion> GetRuntimeWithoutByRefLikeGenericSupportLanguageVersions()
+    {
+        return new TheoryData<LanguageVersion>
+        {
+            LanguageVersion.CSharp12,
+            LanguageVersion.CSharp13,
+            LanguageVersion.Latest,
+            LanguageVersion.Preview,
+        };
+    }
+
     [Fact]
     public async Task PolyfillExtensions_NotGenerated_WhenNoPolyfillsRequired()
     {

--- a/Meziantou.Polyfill.Tests/SystemTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemTests.cs
@@ -1334,6 +1334,21 @@ public class SystemTests
     }
 
     [Fact]
+    public void String_Create_TState()
+    {
+        var actual = string.Create(3, "abc", static (span, state) => state.AsSpan().CopyTo(span));
+        Assert.Equal("abc", actual);
+
+        var called = false;
+        var empty = string.Create(0, 0, (span, state) => called = true);
+        Assert.Empty(empty);
+        Assert.False(called);
+
+        Assert.Throws<ArgumentNullException>(() => string.Create(1, 0, null!));
+        Assert.Throws<ArgumentOutOfRangeException>(() => string.Create(-1, 0, static (span, state) => { }));
+    }
+
+    [Fact]
     public void Single_Parse_ReadOnlySpan_Byte_IFormatProvider()
     {
         // Basic parsing from UTF8

--- a/README.md
+++ b/README.md
@@ -52,11 +52,12 @@ The filtering logic works as follows:
 
 <!-- begin_polyfills -->
 
-### Types (71)
+### Types (72)
 
 - `System.Buffers.SearchValues`
 - `System.Buffers.SearchValues<T> where T : System.IEquatable<T>?`
 - `System.Buffers.SequenceReader<T> where T : unmanaged, System.IEquatable<T>`
+- `System.Buffers.SpanAction<T, in TArg> where TArg : allows ref struct`
 - `System.Collections.Generic.KeyValuePair`
 - `System.Collections.Generic.PriorityQueue<TElement, TPriority>`
 - `System.Collections.Generic.ReferenceEqualityComparer`
@@ -126,7 +127,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (546)
+### Methods (547)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -573,6 +574,7 @@ The filtering logic works as follows:
 - `System.String.Contains(System.String value, System.StringComparison comparisonType)`
 - `System.String.CopyTo(System.Span<System.Char> destination)`
 - `System.String.Create(System.IFormatProvider? provider, ref System.Runtime.CompilerServices.DefaultInterpolatedStringHandler handler)`
+- `System.String.Create<TState>(System.Int32 length, TState state, System.Buffers.SpanAction<System.Char, TState> action) where TState : allows ref struct`
 - `System.String.EndsWith(System.Char value)`
 - `System.String.GetHashCode(System.ReadOnlySpan<System.Char> value)`
 - `System.String.GetHashCode(System.ReadOnlySpan<System.Char> value, System.StringComparison comparisonType)`


### PR DESCRIPTION
# Why

`string.Create` is used in performance needed code, currently I'm using `#if NET` but I having to de-duplicate would be nice.

# What changed

- Added polyfill for `string Create<TState>(int length, TState state, SpanAction<char, TState> action)`