### PR TITLE
Fix RandomNumberGenerator.Fill

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.Security.Cryptography.RandomNumberGenerator.Fill(System.Span{System.Byte}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Security.Cryptography.RandomNumberGenerator.Fill(System.Span{System.Byte}).cs
@@ -1,24 +1,26 @@
 partial class PolyfillExtensions
 {
-    public static void Fill(this System.Security.Cryptography.RandomNumberGenerator random, System.Span<byte> data)
+    extension(System.Security.Cryptography.RandomNumberGenerator)
     {
-        if (random is null)
+        public static void Fill(System.Span<byte> data)
         {
-            throw new System.ArgumentNullException(nameof(random));
-        }
+            if (data.IsEmpty)
+                return;
 
-        if (data.IsEmpty)
-            return;
+            byte[] array = new byte[data.Length];
+            try
+            {
+                using (var random = System.Security.Cryptography.RandomNumberGenerator.Create())
+                {
+                    random.GetBytes(array);
+                }
 
-        byte[] array = new byte[data.Length];
-        try
-        {
-            random.GetBytes(array);
-            new System.ReadOnlySpan<byte>(array).CopyTo(data);
-        }
-        finally
-        {
-            System.Array.Clear(array, 0, array.Length);
+                new System.ReadOnlySpan<byte>(array).CopyTo(data);
+            }
+            finally
+            {
+                System.Array.Clear(array, 0, array.Length);
+            }
         }
     }
 }

--- a/Meziantou.Polyfill.Tests/RandomNumberGeneratorTests.cs
+++ b/Meziantou.Polyfill.Tests/RandomNumberGeneratorTests.cs
@@ -11,9 +11,8 @@ public sealed class RandomNumberGeneratorTests
     [Fact]
     public void Fill_Span_FillsWithRandomBytes()
     {
-        using var rng = RandomNumberGenerator.Create();
         Span<byte> buffer = new byte[100];
-        rng.Fill(buffer);
+        RandomNumberGenerator.Fill(buffer);
 
         // Check that not all bytes are zero (very unlikely with random data)
         Assert.Contains(buffer.ToArray(), b => b != 0);
@@ -22,9 +21,8 @@ public sealed class RandomNumberGeneratorTests
     [Fact]
     public void Fill_EmptySpan_DoesNotThrow()
     {
-        using var rng = RandomNumberGenerator.Create();
         Span<byte> buffer = Span<byte>.Empty;
-        rng.Fill(buffer);
+        RandomNumberGenerator.Fill(buffer);
     }
 #endif
 


### PR DESCRIPTION
RandomNumberGenerator.Fill is a static method, not an instance method.

**Docs:**
https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.randomnumbergenerator.fill

**Source:** https://github.com/dotnet/dotnet/blob/c48424566baad078f3b456c12cb3373772d2ab0a/src/runtime/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RandomNumberGenerator.cs#L98