### PR TITLE
Fix empty ReadOnlySpan handling in Encoding polyfills

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.Text.Encoding.GetCharCount(System.ReadOnlySpan{System.Byte}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Text.Encoding.GetCharCount(System.ReadOnlySpan{System.Byte}).cs
@@ -11,6 +11,9 @@ static partial class PolyfillExtensions
     /// <returns>The number of characters produced by decoding the byte span.</returns>
     public static int GetCharCount(this Encoding target, ReadOnlySpan<byte> bytes)
     {
+        if (bytes.IsEmpty)
+            return 0;
+
 #if MEZIANTOU_POLYFILL_SUPPORT_UNSAFE
         unsafe
         {

--- a/Meziantou.Polyfill.Editor/M;System.Text.Encoding.GetString(System.ReadOnlySpan{System.Byte}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Text.Encoding.GetString(System.ReadOnlySpan{System.Byte}).cs
@@ -11,6 +11,9 @@ static partial class PolyfillExtensions
     /// <returns>A string that contains the decoded bytes from the provided read-only span.</returns>
     public static string GetString(this Encoding target, ReadOnlySpan<byte> bytes)
     {
+        if (bytes.IsEmpty)
+            return string.Empty;
+
 #if MEZIANTOU_POLYFILL_SUPPORT_UNSAFE
         unsafe
         {

--- a/Meziantou.Polyfill.Tests/SystemTextTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemTextTests.cs
@@ -38,6 +38,13 @@ public class SystemTextTests
     }
 
     [Fact]
+    public void Encoding_GetString_Empty()
+    {
+        var str = Encoding.UTF8.GetString(ReadOnlySpan<byte>.Empty);
+        Assert.Equal(string.Empty, str);
+    }
+
+    [Fact]
     public void StringBuilder_AppendJoin_String_ObjectArray()
     {
         var sb = new StringBuilder();
@@ -153,6 +160,13 @@ public class SystemTextTests
         var actual = encoding.GetCharCount(bytes.AsSpan());
         
         Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void Encoding_GetCharCount_Empty()
+    {
+        var actual = Encoding.UTF8.GetCharCount(ReadOnlySpan<byte>.Empty);
+        Assert.Equal(0, actual);
     }
 
     [Fact]


### PR DESCRIPTION
## Why
The CI `tests` job is failing on .NET Framework targets with `System.ArgumentNullException: Array cannot be null` when numeric UTF-8 `TryParse` overloads are called with an empty `ReadOnlySpan<byte>`. Those paths flow through the `Encoding.GetString(ReadOnlySpan<byte>)` polyfill, which currently calls the unsafe pointer overload even for empty spans.

## What changed
- Added an empty-span fast path in `Encoding.GetString(ReadOnlySpan<byte>)` to return `string.Empty`.
- Added an empty-span fast path in `Encoding.GetCharCount(ReadOnlySpan<byte>)` to return `0` for consistency.
- Added regression tests in `SystemTextTests` for both empty-span behaviors.

## Notes for reviewers
This is intentionally minimal and behavior-preserving for non-empty inputs. The change only affects the empty-span edge case that was throwing on .NET Framework and cascading into parse test failures.