### PR TITLE
Add polyfill for TextWriter.CreateBroadcasting

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.IO.TextWriter.CreateBroadcasting(System.IO.TextWriter[]).cs
+++ b/Meziantou.Polyfill.Editor/M;System.IO.TextWriter.CreateBroadcasting(System.IO.TextWriter[]).cs
@@ -1,0 +1,419 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+partial class PolyfillExtensions
+{
+    extension(TextWriter)
+    {
+        public static TextWriter CreateBroadcasting(params TextWriter[] writers)
+        {
+            if (writers is null)
+                throw new ArgumentNullException(nameof(writers));
+
+            if (writers.Length == 0)
+                return TextWriter.Null;
+
+            var copy = new TextWriter[writers.Length];
+            Array.Copy(writers, copy, writers.Length);
+            return new BroadcastingTextWriter(copy);
+        }
+    }
+}
+
+file sealed class BroadcastingTextWriter : TextWriter
+{
+    private readonly TextWriter[] _writers;
+
+    public BroadcastingTextWriter(TextWriter[] writers)
+    {
+        for (var i = 0; i < writers.Length; i++)
+        {
+            if (writers[i] is null)
+                throw new ArgumentNullException(nameof(writers));
+        }
+
+        _writers = writers;
+    }
+
+    public override Encoding Encoding => _writers[0].Encoding;
+
+    public override IFormatProvider FormatProvider => _writers[0].FormatProvider;
+
+    public override string NewLine
+    {
+        get => base.NewLine;
+        set
+        {
+            base.NewLine = value;
+            for (var i = 0; i < _writers.Length; i++)
+            {
+                _writers[i].NewLine = value;
+            }
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (!disposing)
+            return;
+
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Dispose();
+        }
+    }
+
+    public override void Flush()
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Flush();
+        }
+    }
+
+    public override async Task FlushAsync()
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            await _writers[i].FlushAsync().ConfigureAwait(false);
+        }
+    }
+
+    public override void Write(bool value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(value);
+        }
+    }
+
+    public override void Write(char value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(value);
+        }
+    }
+
+    public override void Write(char[]? buffer)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(buffer);
+        }
+    }
+
+    public override void Write(char[] buffer, int index, int count)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(buffer, index, count);
+        }
+    }
+
+    public override void Write(decimal value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(value);
+        }
+    }
+
+    public override void Write(double value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(value);
+        }
+    }
+
+    public override void Write(float value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(value);
+        }
+    }
+
+    public override void Write(int value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(value);
+        }
+    }
+
+    public override void Write(long value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(value);
+        }
+    }
+
+    public override void Write(object? value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(value);
+        }
+    }
+
+    public override void Write(string? value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(value);
+        }
+    }
+
+    public override void Write(uint value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(value);
+        }
+    }
+
+    public override void Write(ulong value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(value);
+        }
+    }
+
+    public override void Write(string format, object? arg0)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(format, arg0);
+        }
+    }
+
+    public override void Write(string format, object? arg0, object? arg1)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(format, arg0, arg1);
+        }
+    }
+
+    public override void Write(string format, object? arg0, object? arg1, object? arg2)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(format, arg0, arg1, arg2);
+        }
+    }
+
+    public override void Write(string format, params object?[] arg)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].Write(format, arg);
+        }
+    }
+
+    public override void WriteLine()
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine();
+        }
+    }
+
+    public override void WriteLine(bool value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(value);
+        }
+    }
+
+    public override void WriteLine(char value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(value);
+        }
+    }
+
+    public override void WriteLine(char[]? buffer)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(buffer);
+        }
+    }
+
+    public override void WriteLine(char[] buffer, int index, int count)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(buffer, index, count);
+        }
+    }
+
+    public override void WriteLine(decimal value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(value);
+        }
+    }
+
+    public override void WriteLine(double value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(value);
+        }
+    }
+
+    public override void WriteLine(float value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(value);
+        }
+    }
+
+    public override void WriteLine(int value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(value);
+        }
+    }
+
+    public override void WriteLine(long value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(value);
+        }
+    }
+
+    public override void WriteLine(object? value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(value);
+        }
+    }
+
+    public override void WriteLine(string? value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(value);
+        }
+    }
+
+    public override void WriteLine(uint value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(value);
+        }
+    }
+
+    public override void WriteLine(ulong value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(value);
+        }
+    }
+
+    public override void WriteLine(string format, object? arg0)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(format, arg0);
+        }
+    }
+
+    public override void WriteLine(string format, object? arg0, object? arg1)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(format, arg0, arg1);
+        }
+    }
+
+    public override void WriteLine(string format, object? arg0, object? arg1, object? arg2)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(format, arg0, arg1, arg2);
+        }
+    }
+
+    public override void WriteLine(string format, params object?[] arg)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            _writers[i].WriteLine(format, arg);
+        }
+    }
+
+    public override async Task WriteAsync(char value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            await _writers[i].WriteAsync(value).ConfigureAwait(false);
+        }
+    }
+
+    public override async Task WriteAsync(string? value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            await _writers[i].WriteAsync(value).ConfigureAwait(false);
+        }
+    }
+
+    public override async Task WriteAsync(char[] buffer, int index, int count)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            await _writers[i].WriteAsync(buffer, index, count).ConfigureAwait(false);
+        }
+    }
+
+    public override async Task WriteLineAsync()
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            await _writers[i].WriteLineAsync().ConfigureAwait(false);
+        }
+    }
+
+    public override async Task WriteLineAsync(char value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            await _writers[i].WriteLineAsync(value).ConfigureAwait(false);
+        }
+    }
+
+    public override async Task WriteLineAsync(string? value)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            await _writers[i].WriteLineAsync(value).ConfigureAwait(false);
+        }
+    }
+
+    public override async Task WriteLineAsync(char[] buffer, int index, int count)
+    {
+        for (var i = 0; i < _writers.Length; i++)
+        {
+            await _writers[i].WriteLineAsync(buffer, index, count).ConfigureAwait(false);
+        }
+    }
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -901,6 +901,10 @@
       "net9.0",
       "net10.0"
     ],
+    "M:System.IO.TextWriter.CreateBroadcasting(System.IO.TextWriter[])": [
+      "net9.0",
+      "net10.0"
+    ],
     "M:System.IO.TextWriter.WriteAsync(System.ReadOnlyMemory{System.Char},System.Threading.CancellationToken)": [
       "netstandard2.1",
       "net6.0",

--- a/Meziantou.Polyfill.Tests/SystemIOTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemIOTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -18,6 +19,65 @@ namespace Meziantou.Polyfill.Tests;
 
 public class SystemIOTests
 {
+    [Fact]
+    public void TextWriter_CreateBroadcasting_WritesToAllWriters()
+    {
+        using var first = new StringWriter();
+        using var second = new StringWriter();
+        using var writer = TextWriter.CreateBroadcasting(first, second);
+
+        writer.Write("test");
+        writer.WriteLine('!');
+
+        Assert.Equal(first.ToString(), second.ToString());
+        Assert.Equal("test!" + writer.NewLine, first.ToString());
+    }
+
+    [Fact]
+    public void TextWriter_CreateBroadcasting_Empty_ReturnsNullWriter()
+    {
+        var writer = TextWriter.CreateBroadcasting();
+        Assert.Same(TextWriter.Null, writer);
+    }
+
+    [Fact]
+    public void TextWriter_CreateBroadcasting_NullArray_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => TextWriter.CreateBroadcasting(null!));
+    }
+
+    [Fact]
+    public void TextWriter_CreateBroadcasting_NullWriter_ThrowsArgumentNullException()
+    {
+        var first = new StringWriter();
+        Assert.Throws<ArgumentNullException>(() => TextWriter.CreateBroadcasting(first, null!));
+    }
+
+    [Fact]
+    public void TextWriter_CreateBroadcasting_ForwardsEncodingAndFormatProviderFromFirstWriter()
+    {
+        var firstProvider = CultureInfo.GetCultureInfo("fr-FR");
+        using var first = new MetadataTextWriter(Encoding.UTF32, firstProvider);
+        using var second = new MetadataTextWriter(Encoding.ASCII, CultureInfo.InvariantCulture);
+        using var writer = TextWriter.CreateBroadcasting(first, second);
+
+        Assert.Same(first.Encoding, writer.Encoding);
+        Assert.Same(first.FormatProvider, writer.FormatProvider);
+    }
+
+    [Fact]
+    public void TextWriter_CreateBroadcasting_WriterExceptionStopsFollowingWriters()
+    {
+        using var first = new StringWriter();
+        using var second = new ThrowingTextWriter();
+        using var third = new StringWriter();
+        using var writer = TextWriter.CreateBroadcasting(first, second, third);
+
+        Assert.Throws<InvalidOperationException>(() => writer.Write('x'));
+        Assert.Equal("x", first.ToString());
+        Assert.Empty(third.ToString());
+    }
+
 #if NET461_OR_GREATER || NETCOREAPP
     [Fact]
     public async Task StreamWriter_WriteAsync()
@@ -265,6 +325,22 @@ public class SystemIOTests
         var to = Path.Combine(Path.GetTempPath(), "testfolder", "child");
         var result = Path.GetRelativePath(from, to);
         Assert.Equal("child", result);
+    }
+
+    private sealed class MetadataTextWriter : StringWriter
+    {
+        private readonly Encoding _encoding;
+
+        public MetadataTextWriter(Encoding encoding, IFormatProvider formatProvider)
+            : base(formatProvider) =>
+            _encoding = encoding;
+
+        public override Encoding Encoding => _encoding;
+    }
+
+    private sealed class ThrowingTextWriter : StringWriter
+    {
+        public override void Write(char value) => throw new InvalidOperationException("boom");
     }
 
 }

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.130</Version>
+    <Version>1.0.131</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (548)
+### Methods (549)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -263,6 +263,7 @@ The filtering logic works as follows:
 - `System.IO.StreamReader.ReadLineAsync(System.Threading.CancellationToken cancellationToken)`
 - `System.IO.TextReader.ReadAsync(System.Memory<System.Char> buffer, [System.Threading.CancellationToken cancellationToken = default])`
 - `System.IO.TextReader.ReadToEndAsync(System.Threading.CancellationToken cancellationToken)`
+- `System.IO.TextWriter.CreateBroadcasting(params System.IO.TextWriter[] writers)`
 - `System.IO.TextWriter.WriteAsync(System.ReadOnlyMemory<System.Char> buffer, [System.Threading.CancellationToken cancellationToken = default])`
 - `System.Int16.Parse(System.ReadOnlySpan<System.Byte> utf8Text, [System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer], [System.IFormatProvider? provider = null])`
 - `System.Int16.Parse(System.ReadOnlySpan<System.Byte> utf8Text, System.IFormatProvider? provider)`


### PR DESCRIPTION
## Why
`TextWriter.CreateBroadcasting` is available in newer runtimes, but consumers targeting older frameworks still need the same API surface and behavior. This adds a polyfill so code can use the API consistently across targets.

## What changed
- Added `M;System.IO.TextWriter.CreateBroadcasting(System.IO.TextWriter[]).cs` with:
  - `TextWriter.CreateBroadcasting(params TextWriter[] writers)`
  - a self-contained `BroadcastingTextWriter` that delegates operations to writers in order
  - null validation and empty-array handling (`TextWriter.Null`)
  - `Encoding` and `FormatProvider` forwarded from the first writer
- Added `SystemIOTests` coverage for:
  - broadcasting writes to all writers
  - null/empty input behavior
  - metadata forwarding from the first writer
  - fail-fast behavior when one writer throws
- Regenerated polyfill metadata and docs updates:
  - `Meziantou.Polyfill.Generator/polyfill-supported-versions.json`
  - `README.md`
- Bumped package version to `1.0.131`.

## Notes
The broadcasting implementation is intentionally ordered and fail-fast to match runtime semantics: if a writer throws, subsequent writers are not invoked for that operation.