### PR TITLE
Add ExtendedLayout/Union and string char comparison polyfills

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.String.EndsWith(System.Char,System.StringComparison).cs
+++ b/Meziantou.Polyfill.Editor/M;System.String.EndsWith(System.Char,System.StringComparison).cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+static partial class PolyfillExtensions
+{
+    public static bool EndsWith(this string target, char value, System.StringComparison comparisonType)
+    {
+        return target.EndsWith(value.ToString(), comparisonType);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.String.StartsWith(System.Char,System.StringComparison).cs
+++ b/Meziantou.Polyfill.Editor/M;System.String.StartsWith(System.Char,System.StringComparison).cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+static partial class PolyfillExtensions
+{
+    public static bool StartsWith(this string target, char value, System.StringComparison comparisonType)
+    {
+        return target.StartsWith(value.ToString(), comparisonType);
+    }
+}

--- a/Meziantou.Polyfill.Editor/T;System.Runtime.CompilerServices.IUnion.cs
+++ b/Meziantou.Polyfill.Editor/T;System.Runtime.CompilerServices.IUnion.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    internal interface IUnion
+    {
+        object? Value { get; }
+    }
+}

--- a/Meziantou.Polyfill.Editor/T;System.Runtime.CompilerServices.UnionAttribute.cs
+++ b/Meziantou.Polyfill.Editor/T;System.Runtime.CompilerServices.UnionAttribute.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
+    internal sealed class UnionAttribute : global::System.Attribute
+    {
+        public UnionAttribute()
+        {
+        }
+    }
+}

--- a/Meziantou.Polyfill.Editor/T;System.Runtime.InteropServices.ExtendedLayoutAttribute.cs
+++ b/Meziantou.Polyfill.Editor/T;System.Runtime.InteropServices.ExtendedLayoutAttribute.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.InteropServices
+{
+    [global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Struct, Inherited = false)]
+    internal sealed class ExtendedLayoutAttribute : global::System.Attribute
+    {
+        public ExtendedLayoutAttribute(global::System.Runtime.InteropServices.ExtendedLayoutKind layoutKind)
+        {
+            LayoutKind = layoutKind;
+        }
+
+        public global::System.Runtime.InteropServices.ExtendedLayoutKind LayoutKind { get; }
+    }
+}

--- a/Meziantou.Polyfill.Editor/T;System.Runtime.InteropServices.ExtendedLayoutKind.cs
+++ b/Meziantou.Polyfill.Editor/T;System.Runtime.InteropServices.ExtendedLayoutKind.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.InteropServices
+{
+    internal enum ExtendedLayoutKind
+    {
+        CStruct = 0,
+        CUnion = 1,
+    }
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -2874,6 +2874,9 @@
       "net10.0",
       "net11.0"
     ],
+    "M:System.String.EndsWith(System.Char,System.StringComparison)": [
+      "net11.0"
+    ],
     "M:System.String.GetHashCode(System.ReadOnlySpan{System.Char})": [
       "net6.0",
       "net7.0",
@@ -3001,6 +3004,9 @@
       "net8.0",
       "net9.0",
       "net10.0",
+      "net11.0"
+    ],
+    "M:System.String.StartsWith(System.Char,System.StringComparison)": [
       "net11.0"
     ],
     "M:System.String.TryCopyTo(System.Span{System.Char})": [
@@ -4105,6 +4111,9 @@
       "net10.0",
       "net11.0"
     ],
+    "T:System.Runtime.CompilerServices.IUnion": [
+      "net11.0"
+    ],
     "T:System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute": [
       "net6.0",
       "net7.0",
@@ -4167,6 +4176,15 @@
       "net8.0",
       "net9.0",
       "net10.0",
+      "net11.0"
+    ],
+    "T:System.Runtime.CompilerServices.UnionAttribute": [
+      "net11.0"
+    ],
+    "T:System.Runtime.InteropServices.ExtendedLayoutAttribute": [
+      "net11.0"
+    ],
+    "T:System.Runtime.InteropServices.ExtendedLayoutKind": [
       "net11.0"
     ],
     "T:System.Runtime.InteropServices.SuppressGCTransitionAttribute": [

--- a/Meziantou.Polyfill.Tests/AttributesTests.cs
+++ b/Meziantou.Polyfill.Tests/AttributesTests.cs
@@ -51,6 +51,7 @@ public class AttributesTests
         _ = new ModuleInitializerAttribute();
         _ = new RequiredMemberAttribute();
         _ = new SkipLocalsInitAttribute();
+        _ = new ExtendedLayoutAttribute(ExtendedLayoutKind.CStruct);
         _ = new SuppressGCTransitionAttribute();
         _ = new UnmanagedCallersOnlyAttribute();
         _ = new ObsoletedOSPlatformAttribute("");
@@ -64,8 +65,22 @@ public class AttributesTests
         _ = new ConstantExpectedAttribute();
         _ = new ExperimentalAttribute("test");
         _ = new OverloadResolutionPriorityAttribute(1);
+        _ = new UnionAttribute();
+
+        _ = ExtendedLayoutKind.CStruct;
+        _ = ExtendedLayoutKind.CUnion;
+        _ = typeof(IUnion);
 
         _ = typeof(IsExternalInit);
+
+        Assert.Null(((IUnion)new CustomUnion(null)).Value);
     }
 
+}
+
+file sealed class CustomUnion : IUnion
+{
+    public CustomUnion(object? value) => Value = value;
+
+    public object? Value { get; }
 }

--- a/Meziantou.Polyfill.Tests/SystemTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemTests.cs
@@ -77,6 +77,15 @@ public class SystemTests
     }
 
     [Fact]
+    public void String_EndsWith_Char_StringComparison()
+    {
+        Assert.True("test".EndsWith('t', StringComparison.Ordinal));
+        Assert.True("test".EndsWith('T', StringComparison.OrdinalIgnoreCase));
+        Assert.False("test".EndsWith('T', StringComparison.Ordinal));
+        Assert.False("".EndsWith('t', StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void String_GetHashCode()
     {
         Assert.Equal("test".GetHashCode(), "test".GetHashCode(StringComparison.Ordinal));
@@ -109,6 +118,15 @@ public class SystemTests
     {
         Assert.True("test".StartsWith('t'));
         Assert.False("test".StartsWith('T'));
+    }
+
+    [Fact]
+    public void String_StartsWith_Char_StringComparison()
+    {
+        Assert.True("test".StartsWith('t', StringComparison.Ordinal));
+        Assert.True("test".StartsWith('T', StringComparison.OrdinalIgnoreCase));
+        Assert.False("test".StartsWith('T', StringComparison.Ordinal));
+        Assert.False("".StartsWith('t', StringComparison.Ordinal));
     }
 
     [Fact]

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.132</Version>
+    <Version>1.0.134</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The filtering logic works as follows:
 
 <!-- begin_polyfills -->
 
-### Types (72)
+### Types (76)
 
 - `System.Buffers.SearchValues`
 - `System.Buffers.SearchValues<T> where T : System.IEquatable<T>?`
@@ -98,6 +98,7 @@ The filtering logic works as follows:
 - `System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute`
 - `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler`
 - `System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute`
+- `System.Runtime.CompilerServices.IUnion`
 - `System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute`
 - `System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute`
 - `System.Runtime.CompilerServices.IsExternalInit`
@@ -106,6 +107,9 @@ The filtering logic works as follows:
 - `System.Runtime.CompilerServices.RequiredMemberAttribute`
 - `System.Runtime.CompilerServices.SkipLocalsInitAttribute`
 - `System.Runtime.CompilerServices.TupleElementNamesAttribute`
+- `System.Runtime.CompilerServices.UnionAttribute`
+- `System.Runtime.InteropServices.ExtendedLayoutAttribute`
+- `System.Runtime.InteropServices.ExtendedLayoutKind`
 - `System.Runtime.InteropServices.SuppressGCTransitionAttribute`
 - `System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute`
 - `System.Runtime.Versioning.ObsoletedOSPlatformAttribute`
@@ -127,7 +131,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (551)
+### Methods (553)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -578,6 +582,7 @@ The filtering logic works as follows:
 - `System.String.Create(System.IFormatProvider? provider, ref System.Runtime.CompilerServices.DefaultInterpolatedStringHandler handler)`
 - `System.String.Create<TState>(System.Int32 length, TState state, System.Buffers.SpanAction<System.Char, TState> action) where TState : allows ref struct`
 - `System.String.EndsWith(System.Char value)`
+- `System.String.EndsWith(System.Char value, System.StringComparison comparisonType)`
 - `System.String.GetHashCode(System.ReadOnlySpan<System.Char> value)`
 - `System.String.GetHashCode(System.ReadOnlySpan<System.Char> value, System.StringComparison comparisonType)`
 - `System.String.GetHashCode(System.StringComparison comparisonType)`
@@ -595,6 +600,7 @@ The filtering logic works as follows:
 - `System.String.Split(System.Char separator, System.Int32 count, [System.StringSplitOptions options = System.StringSplitOptions.None])`
 - `System.String.Split(System.Char separator, [System.StringSplitOptions options = System.StringSplitOptions.None])`
 - `System.String.StartsWith(System.Char value)`
+- `System.String.StartsWith(System.Char value, System.StringComparison comparisonType)`
 - `System.String.TryCopyTo(System.Span<System.Char> destination)`
 - `System.StringComparer.FromComparison(System.StringComparison comparisonType)`
 - `System.Text.Encoding.GetByteCount(System.ReadOnlySpan<System.Char> chars)`


### PR DESCRIPTION
## Why
This adds missing polyfills for newly introduced APIs so projects targeting older frameworks can compile and use the same source patterns.

## What changed
- Added new type polyfills:
  - `System.Runtime.InteropServices.ExtendedLayoutAttribute`
  - `System.Runtime.InteropServices.ExtendedLayoutKind`
  - `System.Runtime.CompilerServices.IUnion`
  - `System.Runtime.CompilerServices.UnionAttribute`
- Added new string overload polyfills:
  - `string.EndsWith(char value, StringComparison comparisonType)`
  - `string.StartsWith(char value, StringComparison comparisonType)`
- Extended tests:
  - Attribute/type availability coverage in `AttributesTests`
  - New behavior tests for both string overloads in `SystemTests`
- Regenerated supported versions metadata and README polyfill listing.
- Bumped package version to `1.0.134`.

## Notes for reviewers
I ran the required validation pipeline (`dotnet run` generator, `dotnet build`, `dotnet test`). The build/test run remains blocked by pre-existing errors unrelated to this change (`CS0117` on `CollectionsMarshal.GetValueRefOrAddDefault` in existing `AggregateBy`/`CountBy` polyfills).