### PR TITLE
Add polyfill for string.LastIndexOf(char, StringComparison)

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.String.LastIndexOf(System.Char,System.StringComparison).cs
+++ b/Meziantou.Polyfill.Editor/M;System.String.LastIndexOf(System.Char,System.StringComparison).cs
@@ -1,0 +1,8 @@
+static partial class PolyfillExtensions
+{
+    public static int LastIndexOf(this string target, char value, System.StringComparison comparisonType)
+    {
+        if (comparisonType == System.StringComparison.Ordinal) return target.LastIndexOf(value);
+        return target.LastIndexOf(value.ToString(), comparisonType);
+    }
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -2954,6 +2954,9 @@
       "net10.0",
       "net11.0"
     ],
+    "M:System.String.LastIndexOf(System.Char,System.StringComparison)": [
+      "net11.0"
+    ],
     "M:System.String.Replace(System.String,System.String,System.StringComparison)": [
       "netstandard2.1",
       "net6.0",

--- a/Meziantou.Polyfill.Tests/SystemTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemTests.cs
@@ -146,6 +146,14 @@ public class SystemTests
     }
 
     [Fact]
+    public void String_LastIndexOf_Char_StringComparison()
+    {
+        Assert.Equal(4, "tEstT".LastIndexOf('t', StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(3, "tEstT".LastIndexOf('t', StringComparison.Ordinal));
+        Assert.Equal(-1, "".LastIndexOf('t', StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void String_IndexOf_Char_StartIndex_StringComparison()
     {
         Assert.Equal(2, "test".IndexOf('S', 1, StringComparison.OrdinalIgnoreCase));

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.134</Version>
+    <Version>1.0.135</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (553)
+### Methods (554)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -594,6 +594,7 @@ The filtering logic works as follows:
 - `System.String.Join(System.Char separator, params System.ReadOnlySpan<System.String?> value)`
 - `System.String.Join(System.Char separator, params System.String?[] value)`
 - `System.String.Join<T>(System.Char separator, System.Collections.Generic.IEnumerable<T> values)`
+- `System.String.LastIndexOf(System.Char value, System.StringComparison comparisonType)`
 - `System.String.Replace(System.String oldValue, System.String? newValue, System.StringComparison comparisonType)`
 - `System.String.ReplaceLineEndings()`
 - `System.String.ReplaceLineEndings(System.String replacementText)`


### PR DESCRIPTION
## Why
`string.LastIndexOf(char, StringComparison)` is available only on newer TFMs, so consumers targeting older frameworks do not have a source-compatible API.

## What changed
- Added a new polyfill for `System.String.LastIndexOf(System.Char,System.StringComparison)`.
- Implemented the same strategy used by existing string-char comparison polyfills:
  - use the native `LastIndexOf(char)` fast path for `StringComparison.Ordinal`
  - otherwise delegate to `LastIndexOf(string, StringComparison)` via `value.ToString()`
- Added tests covering ordinal ignore-case behavior, ordinal behavior, and empty-string behavior.
- Regenerated polyfill metadata/docs updates (`polyfill-supported-versions.json`, `README.md`).
- Bumped package version from `1.0.134` to `1.0.135`.