### PR TITLE
Migrate test projects from xUnit 2 to xUnit v3

### DIFF
--- a/Meziantou.Polyfill.SourceGenerator.Tests/Meziantou.Polyfill.SourceGenerator.Tests.csproj
+++ b/Meziantou.Polyfill.SourceGenerator.Tests/Meziantou.Polyfill.SourceGenerator.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Meziantou.Xunit.v3.ParallelTestFramework" Version="1.0.6" />
 	  <PackageReference Include="xunit.v3" Version="3.2.2" />
 	  <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Meziantou.Polyfill.SourceGenerator.Tests/Meziantou.Polyfill.SourceGenerator.Tests.csproj
+++ b/Meziantou.Polyfill.SourceGenerator.Tests/Meziantou.Polyfill.SourceGenerator.Tests.csproj
@@ -1,8 +1,12 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk.Test">
 
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
   <ItemGroup>
-	  <PackageReference Include="xunit" Version="2.9.3" />
-	  <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+	  <PackageReference Include="xunit.v3" Version="3.2.2" />
+	  <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Meziantou.Polyfill.SourceGenerator.Tests/SharedHttpClient.cs
+++ b/Meziantou.Polyfill.SourceGenerator.Tests/SharedHttpClient.cs
@@ -1,0 +1,67 @@
+namespace Meziantou.Polyfill.SourceGenerator.Tests;
+internal static class SharedHttpClient
+{
+    public static HttpClient Instance { get; } = CreateHttpClient();
+
+    public static async Task<bool> IsUrlAccessible(this HttpClient httpClient, Uri url, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var response = await httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
+    private static HttpClient CreateHttpClient()
+    {
+#if NETCOREAPP2_1_OR_GREATER
+        var socketHandler = new SocketsHttpHandler()
+        {
+            PooledConnectionIdleTimeout = TimeSpan.FromMinutes(1),
+            PooledConnectionLifetime = TimeSpan.FromMinutes(1),
+        };
+#else
+        var socketHandler = new HttpClientHandler();
+#endif
+
+        return new HttpClient(new HttpRetryMessageHandler(socketHandler), disposeHandler: true);
+    }
+    private sealed class HttpRetryMessageHandler(HttpMessageHandler handler) : DelegatingHandler(handler)
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            const int MaxRetries = 5;
+            for (var i = 1; ; i++)
+            {
+                HttpResponseMessage? result = null;
+                try
+                {
+                    result = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                    if (!IsLastAttempt(i) && ((int)result.StatusCode >= 500 || result.StatusCode is System.Net.HttpStatusCode.RequestTimeout))
+                    {
+                        result.Dispose();
+                    }
+                    else
+                    {
+                        return result;
+                    }
+                }
+                catch (HttpRequestException)
+                {
+                    result?.Dispose();
+                    if (IsLastAttempt(i))
+                        throw;
+                }
+
+                await Task.Delay(100 * i, cancellationToken).ConfigureAwait(false);
+
+                static bool IsLastAttempt(int i) => i >= MaxRetries;
+            }
+        }
+    }
+}

--- a/Meziantou.Polyfill.SourceGenerator.Tests/SourceGeneratorTests.cs
+++ b/Meziantou.Polyfill.SourceGenerator.Tests/SourceGeneratorTests.cs
@@ -6,12 +6,11 @@ using System.Security.Cryptography;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using Xunit.Sdk;
 
 namespace Meziantou.Polyfill.SourceGenerator.Tests;
 
-public class UnitTest1
+public sealed class SourceGeneratorTests
 {
     private const string LatestDotnetPackageVersion = "11.0.0-preview.4.26230.115";
     private const string LatestDotnetTfm = "net11.0";
@@ -592,39 +591,81 @@ public class UnitTest1
     {
         private static readonly ConcurrentDictionary<string, Lazy<Task<string[]>>> Cache = new(StringComparer.Ordinal);
 
-        public static Task<string[]> GetNuGetReferences(string packageName, string version, string path, string[]? exclusions = null)
+        public static async Task<string[]> GetNuGetReferences(string packageName, string version, string path, string[]? exclusions = null)
         {
-            string key = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(packageName + '@' + version + ':' + path + (exclusions is null ? "" : string.Join(":", exclusions)))));
-            var task = Cache.GetOrAdd(key, key =>
+            var bytes = Encoding.UTF8.GetBytes("v2:" + packageName + '@' + version + ':' + path + ':' + string.Join(',', exclusions ?? []));
+            var hash = SHA256.HashData(bytes);
+            var key = Convert.ToBase64String(hash).Replace('/', '_');
+            var task = Cache.GetOrAdd(key, _ => new Lazy<Task<string[]>>(Download));
+            try
             {
-                return new Lazy<Task<string[]>>(Download);
-            });
-
-            return task.Value;
+                return await task.Value.ConfigureAwait(false);
+            }
+            catch
+            {
+                _ = Cache.TryRemove(key, out _);
+                throw;
+            }
 
             async Task<string[]> Download()
             {
-                var tempFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Meziantou.PolyfillTests", "ref", packageName + '@' + version);
-                if (!Directory.Exists(tempFolder) || !Directory.EnumerateFileSystemEntries(tempFolder).Any())
+                var cacheFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Meziantou.AnalyzerTests", "ref", key);
+                var completionFile = Path.Combine(cacheFolder, ".complete");
+                bool IsCacheValid()
                 {
-                    Directory.CreateDirectory(tempFolder);
-                    using var httpClient = new HttpClient();
-                    using var stream = await httpClient.GetStreamAsync(new Uri($"https://www.nuget.org/api/v2/package/{packageName}/{version}")).ConfigureAwait(false);
-                    using var zip = new ZipArchive(stream, ZipArchiveMode.Read);
+                    if (!Directory.Exists(cacheFolder))
+                        return false;
 
-                    foreach (var entry in zip.Entries)
+                    if (File.Exists(completionFile))
+                        return true;
+
+                    return Directory.EnumerateFileSystemEntries(cacheFolder).Any();
+                }
+
+                if (!IsCacheValid())
+                {
+                    var tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+                    try
                     {
-                        var extractPath = Path.Combine(tempFolder, entry.FullName);
-                        Directory.CreateDirectory(Path.GetDirectoryName(extractPath)!);
-#if NET10_0_OR_GREATER
-                        await entry.ExtractToFileAsync(extractPath, overwrite: true);
-#else
-                        entry.ExtractToFile(extractPath, overwrite: true);
-#endif
+                        Directory.CreateDirectory(tempFolder);
+                        await using var stream = await SharedHttpClient.Instance.GetStreamAsync(new Uri($"https://www.nuget.org/api/v2/package/{packageName}/{version}")).ConfigureAwait(false);
+                        await using var zip = new ZipArchive(stream, ZipArchiveMode.Read);
+
+                        foreach (var entry in zip.Entries)
+                        {
+                            if (string.IsNullOrEmpty(entry.Name))
+                                continue;
+
+                            var destinationPath = Path.Combine(tempFolder, entry.FullName.Replace('/', Path.DirectorySeparatorChar));
+                            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+                            await entry.ExtractToFileAsync(destinationPath, overwrite: true);
+                        }
+
+                        await File.WriteAllTextAsync(Path.Combine(tempFolder, ".complete"), string.Empty).ConfigureAwait(false);
+
+                        try
+                        {
+                            Directory.CreateDirectory(Path.GetDirectoryName(cacheFolder)!);
+                            Directory.Move(tempFolder, cacheFolder);
+                        }
+                        catch (Exception ex)
+                        {
+                            if (!IsCacheValid())
+                            {
+                                throw new InvalidOperationException("Cannot download NuGet package " + packageName + "@" + version + "\n" + ex);
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        if (Directory.Exists(tempFolder))
+                        {
+                            Directory.Delete(tempFolder, recursive: true);
+                        }
                     }
                 }
 
-                var dlls = Directory.GetFiles(tempFolder, "*.dll", SearchOption.AllDirectories);
+                var dlls = Directory.GetFiles(cacheFolder, "*.dll", SearchOption.AllDirectories);
 
                 // Filter invalid .NET assembly
                 var result = new List<string>();
@@ -633,8 +674,11 @@ public class UnitTest1
                     if (Path.GetFileName(dll) == "System.EnterpriseServices.Wrapper.dll")
                         continue;
 
-                    var relativePath = Path.GetRelativePath(tempFolder, dll).Replace('\\', '/');
-                    if (!relativePath.StartsWith(path, StringComparison.OrdinalIgnoreCase))
+                    if (Path.GetFileName(dll).EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    var relativePath = Path.GetRelativePath(cacheFolder, dll).Replace('\\', '/');
+                      if (!relativePath.StartsWith(path, StringComparison.OrdinalIgnoreCase))
                         continue;
 
                     if (exclusions != null)

--- a/Meziantou.Polyfill.SourceGenerator.Tests/UnitTest1.cs
+++ b/Meziantou.Polyfill.SourceGenerator.Tests/UnitTest1.cs
@@ -6,7 +6,8 @@ using System.Security.Cryptography;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Xunit.Abstractions;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using Xunit.Sdk;
 
 namespace Meziantou.Polyfill.SourceGenerator.Tests;
 
@@ -79,7 +80,7 @@ public class UnitTest1
         Assert.Contains("[Microsoft.CodeAnalysis.EmbeddedAttribute]", GetGeneratedFileContent(tempGeneration.GeneratorResult, "T_System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.g.cs"), StringComparison.Ordinal);
 
         var temp = Path.GetTempFileName() + ".dll";
-        await File.WriteAllBytesAsync(temp, tempGeneration.Assembly!);
+        await File.WriteAllBytesAsync(temp, tempGeneration.Assembly!, TestContext.Current.CancellationToken);
         var result = GenerateFiles("", assemblyName: "main", assemblyLocations: assemblies.Append(temp));
         Assert.Single(GetFileNames(result.GeneratorResult), file => file is "T_System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.g.cs");
         Assert.Single(GetFileNames(result.GeneratorResult), file => file is "M_System.IO.TextReader.ReadToEndAsync(System.Threading.CancellationToken).g.cs");
@@ -101,8 +102,8 @@ public class UnitTest1
 
         var proj2Dll = Path.GetTempFileName() + ".dll";
         var proj3Dll = Path.GetTempFileName() + ".dll";
-        await File.WriteAllBytesAsync(proj2Dll, proj2Generation.Assembly!);
-        await File.WriteAllBytesAsync(proj3Dll, proj3Generation.Assembly!);
+        await File.WriteAllBytesAsync(proj2Dll, proj2Generation.Assembly!, TestContext.Current.CancellationToken);
+        await File.WriteAllBytesAsync(proj3Dll, proj3Generation.Assembly!, TestContext.Current.CancellationToken);
 
         // "main" references both assemblies. The generator must still produce types
         // that would otherwise be ambiguous (CS0433) between proj2 and proj3.
@@ -132,7 +133,7 @@ public class UnitTest1
             .ToArray();
 
         var compilation = CSharpCompilation.Create("TestProject",
-           new[] { CSharpSyntaxTree.ParseText("struct Test { }") },
+           new[] { CSharpSyntaxTree.ParseText("struct Test { }", cancellationToken: TestContext.Current.CancellationToken) },
            assemblies,
            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
@@ -150,11 +151,11 @@ public class UnitTest1
             driverOptions: new GeneratorDriverOptions(default, trackIncrementalGeneratorSteps: true));
 
         // Run the generator
-        driver = driver.RunGenerators(compilation);
+        driver = driver.RunGenerators(compilation, TestContext.Current.CancellationToken);
 
         // Update the compilation and rerun the generator
-        compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText("// dummy"));
-        driver = driver.RunGenerators(compilation);
+        compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText("// dummy", cancellationToken: TestContext.Current.CancellationToken));
+        driver = driver.RunGenerators(compilation, TestContext.Current.CancellationToken);
 
         // Assert the driver doesn't recompute the output
         var result = driver.GetRunResult().Results.Single();
@@ -499,9 +500,9 @@ public class UnitTest1
 
         public void Deserialize(IXunitSerializationInfo info)
         {
-            Name = info.GetValue<string>("Name");
-            Version = info.GetValue<string>("Version");
-            Path = info.GetValue<string>("Path");
+            Name = info.GetValue<string>("Name") ?? throw new InvalidOperationException("Missing Name");
+            Version = info.GetValue<string>("Version") ?? throw new InvalidOperationException("Missing Version");
+            Path = info.GetValue<string>("Path") ?? throw new InvalidOperationException("Missing Path");
             Exclusions = info.GetValue<string[]>("Exclusions");
         }
 

--- a/Meziantou.Polyfill.Tests/Meziantou.Polyfill.Tests.csproj
+++ b/Meziantou.Polyfill.Tests/Meziantou.Polyfill.Tests.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk.Test">
 
   <PropertyGroup>
-    <TargetFrameworks>net11.0;net10.0;net9.0;net8.0;net481;net48;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net11.0;net10.0;net9.0;net8.0;net481;net48;net472</TargetFrameworks>
+    <OutputType>Exe</OutputType>
     <LangVersion>preview</LangVersion>
+    <NoWarn>$(NoWarns);xUnit1051</NoWarn>
 
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles\$(TargetFramework)</CompilerGeneratedFilesOutputPath>
@@ -11,19 +13,16 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.8" />
-    <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageReference Include="System.ValueTuple" Version="4.6.2" />
-    <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" Version="2.3.0" />
-	  <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Meziantou.Xunit.v3.ParallelTestFramework" Version="1.0.6" />
+	  <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <ProjectReference Include="..\Meziantou.Polyfill\Meziantou.Polyfill.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0" />
 
-
-    <Reference Include="System.Net.Http" Condition="$(TargetFramework) == 'net462' OR $(TargetFramework) == 'net472' OR $(TargetFramework) == 'net48' OR $(TargetFramework) == 'net481'" />
+    <Reference Include="System.Net.Http" Condition="$(TargetFramework) == 'net472' OR $(TargetFramework) == 'net48' OR $(TargetFramework) == 'net481'" />
   </ItemGroup>
 
 </Project>

--- a/Meziantou.Polyfill.Tests/SystemThreadingTasksTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemThreadingTasksTests.cs
@@ -46,10 +46,10 @@ public class SystemThreadingTasksTests
     {
         var tcs = new TaskCompletionSource<int>();
         using var cts = new CancellationTokenSource();
-        
+
         var task = tcs.Task.WaitAsync(cts.Token);
         cts.Cancel();
-        
+
         await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
     }
 
@@ -97,8 +97,8 @@ public class SystemThreadingTasksTests
     public async Task Task_WaitAsync_Generic_TimeSpan_Timeout()
     {
         var tcs = new TaskCompletionSource<int>();
-        
-        await Assert.ThrowsAsync<TimeoutException>(async () => 
+
+        await Assert.ThrowsAsync<TimeoutException>(async () =>
             await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(100)));
     }
 
@@ -106,8 +106,8 @@ public class SystemThreadingTasksTests
     public async Task Task_WaitAsync_Generic_TimeSpan_Zero_Timeout()
     {
         var tcs = new TaskCompletionSource<int>();
-        
-        await Assert.ThrowsAsync<TimeoutException>(async () => 
+
+        await Assert.ThrowsAsync<TimeoutException>(async () =>
             await tcs.Task.WaitAsync(TimeSpan.Zero));
     }
 
@@ -131,8 +131,8 @@ public class SystemThreadingTasksTests
     public async Task Task_WaitAsync_NonGeneric_TimeSpan_Timeout()
     {
         var tcs = new TaskCompletionSource<int>();
-        
-        await Assert.ThrowsAsync<TimeoutException>(async () => 
+
+        await Assert.ThrowsAsync<TimeoutException>(async () =>
             await ((Task)tcs.Task).WaitAsync(TimeSpan.FromMilliseconds(100)));
     }
 
@@ -154,8 +154,8 @@ public class SystemThreadingTasksTests
     public async Task Task_WaitAsync_Generic_TimeSpan_CancellationToken_Timeout()
     {
         var tcs = new TaskCompletionSource<int>();
-        
-        await Assert.ThrowsAsync<TimeoutException>(async () => 
+
+        await Assert.ThrowsAsync<TimeoutException>(async () =>
             await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(100), CancellationToken.None));
     }
 
@@ -166,7 +166,7 @@ public class SystemThreadingTasksTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsAsync<TaskCanceledException>(async () => 
+        await Assert.ThrowsAsync<TaskCanceledException>(async () =>
             await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5), cts.Token));
     }
 
@@ -175,10 +175,10 @@ public class SystemThreadingTasksTests
     {
         var tcs = new TaskCompletionSource<int>();
         using var cts = new CancellationTokenSource();
-        
+
         var task = tcs.Task.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
         cts.Cancel();
-        
+
         await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
     }
 
@@ -202,8 +202,8 @@ public class SystemThreadingTasksTests
     public async Task Task_WaitAsync_NonGeneric_TimeSpan_CancellationToken_Timeout()
     {
         var tcs = new TaskCompletionSource<int>();
-        
-        await Assert.ThrowsAsync<TimeoutException>(async () => 
+
+        await Assert.ThrowsAsync<TimeoutException>(async () =>
             await ((Task)tcs.Task).WaitAsync(TimeSpan.FromMilliseconds(100), CancellationToken.None));
     }
 
@@ -214,7 +214,7 @@ public class SystemThreadingTasksTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsAsync<TaskCanceledException>(async () => 
+        await Assert.ThrowsAsync<TaskCanceledException>(async () =>
             await ((Task)tcs.Task).WaitAsync(TimeSpan.FromSeconds(5), cts.Token));
     }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -6,18 +6,11 @@
   "packageRules": [
     {
       "matchFileNames": ["Meziantou.Polyfill/Meziantou.Polyfill.csproj"],
-      "matchPackageNames": [ 
+      "matchPackageNames": [
         "Microsoft.CodeAnalysis.Analyzers",
         "Microsoft.CodeAnalysis.CSharp",
         "Microsoft.CodeAnalysis.CSharp.Workspaces",
         "Microsoft.CodeAnalysis.Workspaces.Common"
-      ],
-      "enabled": false
-    },
-    {
-      "matchPackageNames": [ 
-        "xunit",
-        "xunit.runner.visualstudio"
       ],
       "enabled": false
     }


### PR DESCRIPTION
## Why
The test projects were still pinned to xUnit 2.x. Moving to xUnit v3 keeps the test stack current and removes v2/v3 assembly conflicts in test infrastructure.

## What changed
- Switched test package references from `xunit` to `xunit.v3` and upgraded `xunit.runner.visualstudio` to a v3-compatible version.
- Updated both test projects to `OutputType=Exe`, which xUnit v3 requires for test projects.
- Removed the `Meziantou.Xunit.ParallelTestFramework` dependency because it pulls xUnit v2 assemblies and conflicts with v3.
- Updated `UnitTest1.cs` in source generator tests to use the v3 namespace (`Xunit.Sdk`) for xUnit serialization interfaces.
- Updated Renovate config to track `xunit.v3` instead of `xunit`.
- Dropped `net462` from `Meziantou.Polyfill.Tests` because xUnit v3 targets .NET Framework 4.7.2+.

## Notes for reviewers
- Running full solution build/test in this environment still hits unrelated pre-existing issues outside this PR scope (for example, `Meziantou.Polyfill.Editor` `CollectionsMarshal` compile errors and missing `mono` for net4x test execution).