### PR TITLE
Optimization - Reduce number of comparisons

### DIFF
--- a/Meziantou.Polyfill.Generator/Program.cs
+++ b/Meziantou.Polyfill.Generator/Program.cs
@@ -130,6 +130,74 @@ async Task GenerateMembers()
 {
     var fieldCount = (polyfills.Length / 64) + (polyfills.Length % 64 > 0 ? 1 : 0);
 
+    // Feature-bit allocation: pack _supportExtensions/_supportUnsafe/_supportAllowsRefStruct
+    // and the per-required-type presence flags into a single ulong _features so the table loop
+    // can short-circuit a polyfill with a single AND-compare against entry.RequiredFeatures.
+    const int FeatureBitExtensions = 0;
+    const int FeatureBitUnsafe = 1;
+    const int FeatureBitAllowsRefStruct = 2;
+    var featureBitForType = new Dictionary<string, int>(StringComparer.Ordinal);
+    for (var i = 0; i < requiredTypes.Length; i++)
+    {
+        featureBitForType[requiredTypes[i].TypeName] = 3 + i;
+    }
+    var totalFeatureBits = 3 + requiredTypes.Length;
+    if (totalFeatureBits > 64)
+        throw new InvalidOperationException($"Feature bit count ({totalFeatureBits}) exceeds 64; widen _features.");
+
+    // Build the ordered table of entries plus the flat conditional/declared arrays.
+    var conditionals = new List<(byte FieldIndex, ulong Mask)>();
+    var declaredDocIds = new List<string>();
+    var tableEntries = new List<(Polyfill Polyfill, sbyte ProvidesFeatureBit, ushort CondStart, byte CondCount, ushort DeclStart, byte DeclCount, ulong RequiredFeatures)>();
+
+    void AddEntry(Polyfill polyfill, int? providesFeatureBit)
+    {
+        ulong required = 0;
+        if (polyfill.PolyfillData.UseExtensions) required |= 1uL << FeatureBitExtensions;
+        if (polyfill.PolyfillData.UseUnsafe) required |= 1uL << FeatureBitUnsafe;
+        foreach (var rt in polyfill.PolyfillData.RequiredTypes)
+            required |= 1uL << featureBitForType[rt];
+
+        var condStart = (ushort)conditionals.Count;
+        byte condCount = 0;
+        foreach (var member in polyfill.PolyfillData.ConditionalMembers)
+        {
+            var dep = polyfills.Single(p => p.TypeName == member);
+            conditionals.Add(((byte)(dep.Index / 64), dep.CSharpFieldBitMask));
+            checked { condCount++; }
+        }
+
+        var declStart = (ushort)declaredDocIds.Count;
+        byte declCount = 0;
+        if (polyfill.PolyfillData.XmlDocumentationId?.StartsWith("T:", StringComparison.Ordinal) == true
+            && polyfill.PolyfillData.DeclaredMemberDocumentationIds.Length > 0)
+        {
+            foreach (var m in polyfill.PolyfillData.DeclaredMemberDocumentationIds)
+            {
+                declaredDocIds.Add(m);
+                checked { declCount++; }
+            }
+        }
+
+        tableEntries.Add((polyfill, providesFeatureBit.HasValue ? (sbyte)providesFeatureBit.Value : (sbyte)-1, condStart, condCount, declStart, declCount, required));
+    }
+
+    // Pass 1: polyfills whose T: declaration matches a required type. They set the corresponding
+    // feature bit so later entries that depend on the type (via RequiredFeatures) see it as present.
+    foreach (var polyfill in polyfills)
+    {
+        var rt = requiredTypes.SingleOrDefault(t => $"T:{t.TypeName}" == polyfill.PolyfillData.XmlDocumentationId);
+        if (rt is null) continue;
+        AddEntry(polyfill, featureBitForType[rt.TypeName]);
+    }
+    // Pass 2: everything else, in original (topologically-sorted) order so conditional members see earlier bits.
+    foreach (var polyfill in polyfills)
+    {
+        var rt = requiredTypes.SingleOrDefault(t => $"T:{t.TypeName}" == polyfill.PolyfillData.XmlDocumentationId);
+        if (rt is not null) continue;
+        AddEntry(polyfill, null);
+    }
+
     var sb = new StringBuilder();
     sb.AppendLine($$"""
     #nullable enable
@@ -150,116 +218,82 @@ async Task GenerateMembers()
         sb.AppendLine($"private readonly ulong _bits{i} = 0uL;");
     }
 
-    sb.AppendLine($"private readonly PolyfillOptions _options;");
-    sb.AppendLine($"private readonly bool _supportAllowsRefStruct;");
-    sb.AppendLine($"private readonly bool _supportExtensions;");
-    sb.AppendLine($"private readonly bool _supportUnsafe;");
-    sb.AppendLine($"private readonly string _sourcePrefix;");
-
-    foreach (var requiredType in requiredTypes)
-    {
-        sb.AppendLine($"private readonly bool {requiredType.CsharpFieldName};");
-    }
+    sb.AppendLine("private readonly PolyfillOptions _options;");
+    sb.AppendLine("private readonly ulong _features;");
+    sb.AppendLine("private readonly string _sourcePrefix;");
 
     sb.AppendLine("public Members(Compilation compilation, PolyfillOptions options)");
     sb.AppendLine("{");
     sb.AppendLine("    _options = options;");
     sb.AppendLine("    var languageVersion = compilation.SyntaxTrees.FirstOrDefault()?.Options is CSharpParseOptions parseOptions ? parseOptions.LanguageVersion : LanguageVersion.Default;");
     sb.AppendLine("    var runtimeFeature = compilation.GetSpecialType(SpecialType.System_Object).ContainingAssembly.GetTypeByMetadataName(\"System.Runtime.CompilerServices.RuntimeFeature\");");
-    sb.AppendLine("    _supportAllowsRefStruct = Enum.IsDefined(typeof(LanguageVersion), 1300) && languageVersion >= (LanguageVersion)1300 && (runtimeFeature?.GetMembers(\"ByRefLikeGenerics\").Length ?? 0) > 0;");
-    sb.AppendLine("    _supportExtensions = Enum.IsDefined(typeof(LanguageVersion), 1400) && languageVersion >= (LanguageVersion)1400;");
-    sb.AppendLine("    _supportUnsafe = compilation.Options is CSharpCompilationOptions compilationOptions && compilationOptions.AllowUnsafe;");
+    sb.AppendLine("    ulong features = 0uL;");
+    sb.AppendLine($"    if (Enum.IsDefined(typeof(LanguageVersion), 1300) && languageVersion >= (LanguageVersion)1300 && (runtimeFeature?.GetMembers(\"ByRefLikeGenerics\").Length ?? 0) > 0) features |= {1uL << FeatureBitAllowsRefStruct}uL;");
+    sb.AppendLine($"    if (Enum.IsDefined(typeof(LanguageVersion), 1400) && languageVersion >= (LanguageVersion)1400) features |= {1uL << FeatureBitExtensions}uL;");
+    sb.AppendLine($"    if (compilation.Options is CSharpCompilationOptions compilationOptions && compilationOptions.AllowUnsafe) features |= {1uL << FeatureBitUnsafe}uL;");
 
     foreach (var requiredType in requiredTypes)
     {
-        sb.AppendLine($"    {requiredType.CsharpFieldName} = compilation.GetTypeByMetadataName(\"{requiredType.TypeName}\") != null;");
+        var bitMask = 1uL << featureBitForType[requiredType.TypeName];
+        sb.AppendLine($"    if (compilation.GetTypeByMetadataName(\"{requiredType.TypeName}\") != null) features |= {bitMask}uL;");
     }
 
     sb.AppendLine("    var prefixBuilder = new StringBuilder(\"// <auto-generated/>\\n\");");
-    sb.AppendLine("    if (_supportAllowsRefStruct) prefixBuilder.Append(\"#define MEZIANTOU_POLYFILL_SUPPORT_ALLOWS_REF_STRUCT\\n\");");
-    sb.AppendLine("    if (_supportUnsafe) prefixBuilder.Append(\"#define MEZIANTOU_POLYFILL_SUPPORT_UNSAFE\\n\");");
+    sb.AppendLine($"    if ((features & {1uL << FeatureBitAllowsRefStruct}uL) != 0uL) prefixBuilder.Append(\"#define MEZIANTOU_POLYFILL_SUPPORT_ALLOWS_REF_STRUCT\\n\");");
+    sb.AppendLine($"    if ((features & {1uL << FeatureBitUnsafe}uL) != 0uL) prefixBuilder.Append(\"#define MEZIANTOU_POLYFILL_SUPPORT_UNSAFE\\n\");");
     foreach (var requiredType in requiredTypes)
     {
         var defineName = requiredType.TypeName.Replace('`', '_').Replace('.', '_').ToUpperInvariant();
-        sb.AppendLine($"    if({requiredType.CsharpFieldName}) prefixBuilder.Append(\"#define MEZIANTOU_POLYFILL_SUPPORT_{defineName}\\n\");");
+        var bitMask = 1uL << featureBitForType[requiredType.TypeName];
+        sb.AppendLine($"    if ((features & {bitMask}uL) != 0uL) prefixBuilder.Append(\"#define MEZIANTOU_POLYFILL_SUPPORT_{defineName}\\n\");");
     }
     sb.AppendLine("    _sourcePrefix = prefixBuilder.ToString();");
 
-    sb.AppendLine($"    var includeContext = new IncludeContext(compilation, options);");
-    foreach (var polyfill in polyfills)
+    sb.AppendLine("    var includeContext = new IncludeContext(compilation, options);");
+    sb.AppendLine($"    Span<ulong> bits = stackalloc ulong[{fieldCount}];");
+    sb.AppendLine("    ulong feat = features;");
+    sb.AppendLine("    var entries = PolyfillEntries.Entries;");
+    sb.AppendLine("    var conditionals = PolyfillEntries.Conditionals;");
+    sb.AppendLine("    var declared = PolyfillEntries.DeclaredDocIds;");
+    sb.AppendLine("    for (var idx = 0; idx < entries.Length; idx++)");
+    sb.AppendLine("    {");
+    sb.AppendLine("        ref readonly var entry = ref entries[idx];");
+    sb.AppendLine("        if ((feat & entry.RequiredFeatures) != entry.RequiredFeatures) continue;");
+    sb.AppendLine("        if (entry.ConditionalCount > 0)");
+    sb.AppendLine("        {");
+    sb.AppendLine("            var any = false;");
+    sb.AppendLine("            var condEnd = entry.ConditionalStart + entry.ConditionalCount;");
+    sb.AppendLine("            for (var j = (int)entry.ConditionalStart; j < condEnd; j++)");
+    sb.AppendLine("            {");
+    sb.AppendLine("                ref readonly var c = ref conditionals[j];");
+    sb.AppendLine("                if ((bits[c.FieldIndex] & c.Mask) != 0uL) { any = true; break; }");
+    sb.AppendLine("            }");
+    sb.AppendLine("            if (!any) continue;");
+    sb.AppendLine("        }");
+    sb.AppendLine("        if (!IncludeMember(includeContext, entry.DocId)) continue;");
+    sb.AppendLine("        if (entry.DeclaredCount > 0)");
+    sb.AppendLine("        {");
+    sb.AppendLine("            var allOk = true;");
+    sb.AppendLine("            var declEnd = entry.DeclaredStart + entry.DeclaredCount;");
+    sb.AppendLine("            for (var j = (int)entry.DeclaredStart; j < declEnd; j++)");
+    sb.AppendLine("            {");
+    sb.AppendLine("                if (!IncludeMember(includeContext, declared[j])) { allOk = false; break; }");
+    sb.AppendLine("            }");
+    sb.AppendLine("            if (!allOk) continue;");
+    sb.AppendLine("        }");
+    sb.AppendLine("        bits[entry.FieldIndex] |= entry.Mask;");
+    sb.AppendLine("        if (entry.ProvidesFeatureBit >= 0)");
+    sb.AppendLine("        {");
+    sb.AppendLine("            feat |= 1uL << entry.ProvidesFeatureBit;");
+    sb.AppendLine("        }");
+    sb.AppendLine("    }");
+
+    for (var i = 0; i < fieldCount; i++)
     {
-        var requiredType = requiredTypes.SingleOrDefault(rt => $"T:{rt.TypeName}" == polyfill.PolyfillData.XmlDocumentationId);
-        if (requiredType is null)
-            continue;
-
-        sb.AppendLine($"    if ({GenerateIncludePreCondition(polyfill.PolyfillData)}IncludeMember(includeContext, \"{polyfill.TypeName}\"){GenerateIncludePostCondition(polyfill.PolyfillData)})");
-        sb.AppendLine($"    {{");
-        sb.AppendLine($"        {polyfill.CSharpFieldName} = {polyfill.CSharpFieldName} | {polyfill.CSharpFieldBitMask}uL;");
-        sb.AppendLine($"        {requiredType.CsharpFieldName} = true;");
-        sb.AppendLine($"    }}");
+        sb.AppendLine($"    _bits{i} = bits[{i}];");
     }
-
-    foreach (var polyfill in polyfills)
-    {
-        var requiredType = requiredTypes.SingleOrDefault(rt => $"T:{rt.TypeName}" == polyfill.PolyfillData.XmlDocumentationId);
-        if (requiredType is not null)
-            continue;
-
-        sb.AppendLine($"    if ({GenerateIncludePreCondition(polyfill.PolyfillData)}IncludeMember(includeContext, \"{polyfill.TypeName}\"){GenerateIncludePostCondition(polyfill.PolyfillData)})");
-        sb.AppendLine($"        {polyfill.CSharpFieldName} = {polyfill.CSharpFieldName} | {polyfill.CSharpFieldBitMask}uL;");
-
-    }
+    sb.AppendLine("    _features = feat;");
     sb.AppendLine("}");
-
-
-    string GenerateIncludePreCondition(PolyfillData data)
-    {
-        var result = "";
-
-        if (data.UseExtensions)
-        {
-            result += "_supportExtensions && ";
-        }
-
-        if (data.UseUnsafe)
-        {
-            result += "_supportUnsafe && ";
-        }
-
-        foreach (var requiredType in data.RequiredTypes)
-        {
-            result += requiredTypes.Single(t => t.TypeName == requiredType).CsharpFieldName + " && ";
-        }
-
-        if (data.ConditionalMembers.Length > 0)
-        {
-            result += "(";
-            result += string.Join(" || ", data.ConditionalMembers.Select(member =>
-            {
-                var dependency = polyfills.Single(p => p.TypeName == member);
-                return $"({dependency.CSharpFieldName} & {dependency.CSharpFieldBitMask}uL) == {dependency.CSharpFieldBitMask}uL";
-            }));
-            result += ") && ";
-        }
-        return result;
-    }
-
-    string GenerateIncludePostCondition(PolyfillData data)
-    {
-        var result = "";
-        if (data.XmlDocumentationId?.StartsWith("T:", StringComparison.Ordinal) == true && data.DeclaredMemberDocumentationIds.Length > 0)
-        {
-            result += " && (";
-            result += string.Join(" && ", data.DeclaredMemberDocumentationIds.Select(member =>
-            {
-                // Do not use "options" as the member cannot be part of Included or Excluded members
-                return $"IncludeMember(includeContext, \"{member}\")";
-            }));
-            result += ")";
-        }
-
-        return result;
-    }
 
     sb.AppendLine("public override int GetHashCode()");
     sb.AppendLine("{");
@@ -309,7 +343,8 @@ async Task GenerateMembers()
     sb.AppendLine("    sb.AppendLine(_options.DumpAsCSharpComment());");
     foreach (var requiredType in requiredTypes)
     {
-        sb.AppendLine($"    sb.AppendLine(\"// {requiredType.TypeName}: \" + {requiredType.CsharpFieldName});");
+        var bitMask = 1uL << featureBitForType[requiredType.TypeName];
+        sb.AppendLine($"    sb.AppendLine(\"// {requiredType.TypeName}: \" + ((_features & {bitMask}uL) != 0uL));");
     }
 
     sb.AppendLine("    sb.AppendLine(\"//\");");
@@ -366,6 +401,37 @@ async Task GenerateMembers()
 
     sb.AppendLine("}");
 
+    // Emit the static table data. Kept in a file-scoped class so it is private to this file
+    // and the JIT can compile the much smaller constructor without inlining 30k lines of bit-OR.
+    sb.AppendLine();
+    sb.AppendLine("file static class PolyfillEntries");
+    sb.AppendLine("{");
+    sb.AppendLine("    public static readonly PolyfillEntry[] Entries = new PolyfillEntry[]");
+    sb.AppendLine("    {");
+    foreach (var e in tableEntries)
+    {
+        sb.AppendLine($"        new PolyfillEntry({(byte)(e.Polyfill.Index / 64)}, {e.CondCount}, {e.DeclCount}, {e.ProvidesFeatureBit}, {e.CondStart}, {e.DeclStart}, {e.Polyfill.CSharpFieldBitMask}uL, {e.RequiredFeatures}uL, \"{EscapeStringLiteral(e.Polyfill.TypeName)}\"),");
+    }
+    sb.AppendLine("    };");
+
+    sb.AppendLine("    public static readonly ConditionalCheck[] Conditionals = new ConditionalCheck[]");
+    sb.AppendLine("    {");
+    foreach (var c in conditionals)
+    {
+        sb.AppendLine($"        new ConditionalCheck({c.FieldIndex}, {c.Mask}uL),");
+    }
+    sb.AppendLine("    };");
+
+    sb.AppendLine("    public static readonly string[] DeclaredDocIds = new string[]");
+    sb.AppendLine("    {");
+    foreach (var d in declaredDocIds)
+    {
+        sb.AppendLine($"        \"{EscapeStringLiteral(d)}\",");
+    }
+    sb.AppendLine("    };");
+    sb.AppendLine("}");
+
+    sb.AppendLine();
     sb.AppendLine("file static class PolyfillContents");
     sb.AppendLine("{");
     foreach (var polyfill in polyfills)
@@ -376,11 +442,13 @@ async Task GenerateMembers()
     }
     sb.AppendLine("}");
 
-    Console.WriteLine(sb.ToString());
     Console.WriteLine("Polyfills: " + polyfills.Length);
     var path = GetMemberFilePath();
     Console.WriteLine(path);
     await File.WriteAllTextAsync(path, sb.ToString());
+
+    static string EscapeStringLiteral(string value)
+        => value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal);
 }
 
 async Task GenerateReadme()

--- a/Meziantou.Polyfill/ConditionalCheck.cs
+++ b/Meziantou.Polyfill/ConditionalCheck.cs
@@ -1,0 +1,16 @@
+using System.Runtime.InteropServices;
+
+namespace Meziantou.Polyfill;
+
+[StructLayout(LayoutKind.Auto)]
+internal readonly struct ConditionalCheck
+{
+    public readonly byte FieldIndex;
+    public readonly ulong Mask;
+
+    public ConditionalCheck(byte fieldIndex, ulong mask)
+    {
+        FieldIndex = fieldIndex;
+        Mask = mask;
+    }
+}

--- a/Meziantou.Polyfill/PolyfillEntry.cs
+++ b/Meziantou.Polyfill/PolyfillEntry.cs
@@ -1,0 +1,30 @@
+using System.Runtime.InteropServices;
+
+namespace Meziantou.Polyfill;
+
+[StructLayout(LayoutKind.Auto)]
+internal readonly struct PolyfillEntry
+{
+    public readonly byte FieldIndex;
+    public readonly byte ConditionalCount;
+    public readonly byte DeclaredCount;
+    public readonly sbyte ProvidesFeatureBit; // -1 when the polyfill does not provide a required-type feature
+    public readonly ushort ConditionalStart;
+    public readonly ushort DeclaredStart;
+    public readonly ulong Mask;
+    public readonly ulong RequiredFeatures;
+    public readonly string DocId;
+
+    public PolyfillEntry(byte fieldIndex, byte conditionalCount, byte declaredCount, sbyte providesFeatureBit, ushort conditionalStart, ushort declaredStart, ulong mask, ulong requiredFeatures, string docId)
+    {
+        FieldIndex = fieldIndex;
+        ConditionalCount = conditionalCount;
+        DeclaredCount = declaredCount;
+        ProvidesFeatureBit = providesFeatureBit;
+        ConditionalStart = conditionalStart;
+        DeclaredStart = declaredStart;
+        Mask = mask;
+        RequiredFeatures = requiredFeatures;
+        DocId = docId;
+    }
+}


### PR DESCRIPTION
## The problem we were solving

The old generated `Members(Compilation, PolyfillOptions)` constructor was a ~1400-line straight-line method, one `if` per polyfill:

```csharp
if (_supportExtensions && _System_ReadOnlySpan_1 && IncludeMember(includeContext, "M:System.Decimal.Parse(...)"))
    _bits0 = _bits0 | 1099511627776uL;
if (_supportExtensions && IncludeMember(includeContext, "M:System.Enum.Parse``1(System.String)"))
    _bits0 = _bits0 | 70368744177664uL;
// ... 659 of these
```

Every `_supportX` / `_System_Y` check was hand-inlined per polyfill. Cheap to execute, but the JIT has to compile all 1400 lines on first use, and the resulting method body is huge.

## The new shape

```
659 if-statements  →  1 loop over a 659-entry static array
20 bool fields     →  1 ulong _features (one bit per feature)
hand-inlined gates →  one AND-compare per entry: (feat & entry.RequiredFeatures) != entry.RequiredFeatures
```

## Step 1: Pack all booleans into one `ulong`

The original constructor maintained 20 separate `bool` fields:

- `_supportExtensions`, `_supportUnsafe`, `_supportAllowsRefStruct` (3 language/runtime flags)
- `_System_Buffers_SpanAction_2`, `_System_DateOnly`, `_System_ReadOnlySpan_1`, … (17 "is this BCL type present?" flags)

In the new code, these are bits in a single `ulong _features`:

| Bit | Meaning |
|-----|---------|
| 0   | extensions supported |
| 1   | unsafe allowed |
| 2   | `allows ref struct` supported |
| 3   | `System.Buffers.SpanAction\`2` present |
| 4   | `System.Collections.Generic.IAsyncEnumerable\`1` present |
| …   | … 14 more required types … |
| 19  | `System.TimeOnly` present |

The constructor sets these bits up front:

```csharp
ulong features = 0uL;
if (... languageVersion >= 1400) features |= 1uL;           // bit 0
if (... AllowUnsafe)             features |= 2uL;           // bit 1
if (... ByRefLikeGenerics ...)   features |= 4uL;           // bit 2
if (compilation.GetTypeByMetadataName("System.ReadOnlySpan`1") != null)
    features |= 4096uL;                                     // bit 12
// ... 14 more lines
```

## Step 2: Each polyfill becomes one row in a static table

The generator emits one `PolyfillEntry` per polyfill in a `file static class PolyfillEntries`:

```csharp
public static readonly PolyfillEntry[] Entries = new[]
{
    //              FieldIdx CondCnt DeclCnt ProvidesBit CondStart DeclStart  Mask                  RequiredFeatures  DocId
    new PolyfillEntry(    0,      0,       0,         -1,       0,        0,  1uL,                  1uL,              "M:System.Enum.TryParse``1(System.String,System.Boolean,``0@)"),
    new PolyfillEntry(    0,      0,       0,         -1,       0,        0,  262144uL,             4097uL,           "M:System.BitConverter.ToInt16(System.ReadOnlySpan{System.Byte})"),
    // ...
};
```

Reading row 2: this polyfill writes mask `262144` (= 2¹⁸) into `_bits0`, requires features mask `4097` (= bit 0 *and* bit 12 — i.e. extensions support **and** `ReadOnlySpan<T>` present), has no conditional dependencies, and provides no feature itself.

`RequiredFeatures` is the magic field. It collapses what used to be `_supportExtensions && _System_ReadOnlySpan_1 && …` into a single `ulong` mask. The runtime check then becomes:

```csharp
if ((feat & entry.RequiredFeatures) != entry.RequiredFeatures) continue;
```

That single AND-compare tests **all** prerequisites at once. If even one required bit is missing in `feat`, skip the row.

## Step 3: The loop

Here's the full loop (slightly simplified):

```csharp
Span<ulong> bits = stackalloc ulong[11];   // accumulators for _bits0.._bits10
ulong feat = features;
var entries     = PolyfillEntries.Entries;
var conditionals= PolyfillEntries.Conditionals;
var declared    = PolyfillEntries.DeclaredDocIds;

for (var idx = 0; idx < entries.Length; idx++)
{
    ref readonly var entry = ref entries[idx];

    // (a) feature gate — one AND-compare
    if ((feat & entry.RequiredFeatures) != entry.RequiredFeatures) continue;

    // (b) conditional dependencies (OR semantics: any one must be set)
    if (entry.ConditionalCount > 0)
    {
        var any = false;
        for (var j = entry.ConditionalStart; j < entry.ConditionalStart + entry.ConditionalCount; j++)
        {
            ref readonly var c = ref conditionals[j];
            if ((bits[c.FieldIndex] & c.Mask) != 0uL) { any = true; break; }
        }
        if (!any) continue;
    }

    // (c) the actual symbol-resolution check (the expensive one)
    if (!IncludeMember(includeContext, entry.DocId)) continue;

    // (d) declared-member post-check (currently unused, AND semantics)
    if (entry.DeclaredCount > 0) { /* ... AND over declared[j] ... */ }

    // (e) record the polyfill as enabled
    bits[entry.FieldIndex] |= entry.Mask;

    // (f) if this is a T: polyfill that provides a required type, set its feature bit
    if (entry.ProvidesFeatureBit >= 0)
        feat |= 1uL << entry.ProvidesFeatureBit;
}

_bits0  = bits[0];  _bits1 = bits[1];  …  _bits10 = bits[10];
_features = feat;
```

Each row goes through up to six checks, but **(a)** rejects the vast majority cheaply — a single AND and compare against a 64-bit value.

## Step 4: Why the ordering matters (the two passes)

Some polyfills provide a feature when enabled — for example, polyfilling `System.Runtime.CompilerServices.DefaultInterpolatedStringHandler` means *after* this polyfill is emitted, that type effectively exists, and downstream polyfills that depend on it should see it as available.

The original generator handled this by emitting all "provides-a-feature" polyfills first, then everything else. The new generator preserves that exact ordering when building the table — pass 1 entries come first (with `ProvidesFeatureBit >= 0`), pass 2 entries after. Since the loop walks the table in order and step **(f)** updates `feat` immediately, later rows see the bit set.

The `ConditionalMembers` dependencies (rare; ~9 polyfills) work the same way: they reference bits set by *earlier* rows in the table, so a forward-only loop is sufficient. The conditionals don't store doc IDs — they store `(FieldIndex, Mask)` pairs that read directly from the local `bits` Span we're accumulating into.

## Step 5: Why this is faster

| Aspect | Before | After |
|--------|--------|-------|
| Constructor IL size | ~1400 lines / huge method body | ~95 lines / tight loop |
| Per-polyfill gate code | hand-inlined `&&` chain (varies, 1–5 field reads) | one AND-compare on a `ulong` |
| Boolean storage | 20 separate `bool` fields | 1 `ulong` field |
| JIT cost on first compile | high — the JIT has to compile a 1400-line method | low — small loop body |
| Runtime cost per skipped polyfill | a few field reads + branch | one struct field load + AND + branch |

The runtime per-call cost is actually similar (modern branch predictors handle both well), but **JIT cost** drops dramatically. For a Roslyn analyzer loaded in `csc.exe` / Visual Studio / OmniSharp, that's the cost that matters: it's paid every time the analyzer loads into a new process.

## What didn't change

- `Members.Equals` / `GetHashCode` / `HasAnyPolyfill` still compare only `_bits0..10` — same equality semantics as before. Two `Members` instances are equal iff the same polyfills are enabled.
- `AddSources` still has one hand-inlined `if ((_bitsN & mask) != 0)` per polyfill — that code only runs when `Members` actually changes (rare), so it wasn't a hot path.
- The polyfill source text (the massive `file static class PolyfillContents`) is unchanged.

## The trade-off

The cost is more indirection: every polyfill check now dereferences a `PolyfillEntry` struct from an array. In return we get a one-time JIT win, a smaller compiled assembly footprint for the hot constructor, and a single AND-compare gate that replaces what was an unbounded `&&` chain. For an analyzer DLL that gets loaded fresh into many compiler processes per day, that's the right trade.
