### PR TITLE
Add .NET 11 polyfills and refresh supported version data

### DIFF
--- a/Meziantou.Polyfill.Editor/F;System.Net.Mime.MediaTypeNames.Video.Mp4.cs
+++ b/Meziantou.Polyfill.Editor/F;System.Net.Mime.MediaTypeNames.Video.Mp4.cs
@@ -1,0 +1,15 @@
+// define-type System.Net.Mime.MediaTypeNames.Video
+static partial class PolyfillExtensions
+{
+#if MEZIANTOU_POLYFILL_TYPE_SYSTEM_NET_MIME_MEDIATYPENAMES_VIDEO
+    extension(System.Net.Mime.MediaTypeNames.Video)
+    {
+        public static string Mp4 => "video/mp4";
+    }
+#else
+    extension(MediaTypeNamesVideoPolyfill instance)
+    {
+        public string Mp4 => "video/mp4";
+    }
+#endif
+}

--- a/Meziantou.Polyfill.Editor/F;System.Net.Mime.MediaTypeNames.Video.Mpeg.cs
+++ b/Meziantou.Polyfill.Editor/F;System.Net.Mime.MediaTypeNames.Video.Mpeg.cs
@@ -1,0 +1,15 @@
+// define-type System.Net.Mime.MediaTypeNames.Video
+static partial class PolyfillExtensions
+{
+#if MEZIANTOU_POLYFILL_TYPE_SYSTEM_NET_MIME_MEDIATYPENAMES_VIDEO
+    extension(System.Net.Mime.MediaTypeNames.Video)
+    {
+        public static string Mpeg => "video/mpeg";
+    }
+#else
+    extension(MediaTypeNamesVideoPolyfill instance)
+    {
+        public string Mpeg => "video/mpeg";
+    }
+#endif
+}

--- a/Meziantou.Polyfill.Editor/F;System.Net.Mime.MediaTypeNames.Video.Ogg.cs
+++ b/Meziantou.Polyfill.Editor/F;System.Net.Mime.MediaTypeNames.Video.Ogg.cs
@@ -1,0 +1,15 @@
+// define-type System.Net.Mime.MediaTypeNames.Video
+static partial class PolyfillExtensions
+{
+#if MEZIANTOU_POLYFILL_TYPE_SYSTEM_NET_MIME_MEDIATYPENAMES_VIDEO
+    extension(System.Net.Mime.MediaTypeNames.Video)
+    {
+        public static string Ogg => "video/ogg";
+    }
+#else
+    extension(MediaTypeNamesVideoPolyfill instance)
+    {
+        public string Ogg => "video/ogg";
+    }
+#endif
+}

--- a/Meziantou.Polyfill.Editor/F;System.Net.Mime.MediaTypeNames.Video.QuickTime.cs
+++ b/Meziantou.Polyfill.Editor/F;System.Net.Mime.MediaTypeNames.Video.QuickTime.cs
@@ -1,0 +1,15 @@
+// define-type System.Net.Mime.MediaTypeNames.Video
+static partial class PolyfillExtensions
+{
+#if MEZIANTOU_POLYFILL_TYPE_SYSTEM_NET_MIME_MEDIATYPENAMES_VIDEO
+    extension(System.Net.Mime.MediaTypeNames.Video)
+    {
+        public static string QuickTime => "video/quicktime";
+    }
+#else
+    extension(MediaTypeNamesVideoPolyfill instance)
+    {
+        public string QuickTime => "video/quicktime";
+    }
+#endif
+}

--- a/Meziantou.Polyfill.Editor/F;System.Net.Mime.MediaTypeNames.Video.WebM.cs
+++ b/Meziantou.Polyfill.Editor/F;System.Net.Mime.MediaTypeNames.Video.WebM.cs
@@ -1,0 +1,15 @@
+// define-type System.Net.Mime.MediaTypeNames.Video
+static partial class PolyfillExtensions
+{
+#if MEZIANTOU_POLYFILL_TYPE_SYSTEM_NET_MIME_MEDIATYPENAMES_VIDEO
+    extension(System.Net.Mime.MediaTypeNames.Video)
+    {
+        public static string WebM => "video/webm";
+    }
+#else
+    extension(MediaTypeNamesVideoPolyfill instance)
+    {
+        public string WebM => "video/webm";
+    }
+#endif
+}

--- a/Meziantou.Polyfill.Editor/M;System.Collections.Generic.EqualityComparer`1.Create``1(System.Func{`0,``0},System.Collections.Generic.IEqualityComparer{``0}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Collections.Generic.EqualityComparer`1.Create``1(System.Func{`0,``0},System.Collections.Generic.IEqualityComparer{``0}).cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+
+static partial class PolyfillExtensions
+{
+    extension<T>(EqualityComparer<T>)
+    {
+        public static EqualityComparer<T> Create<TKey>(Func<T?, TKey?> keySelector, IEqualityComparer<TKey>? keyComparer = null)
+        {
+            if (keySelector is null)
+                throw new ArgumentNullException(nameof(keySelector));
+
+            return new KeySelectorEqualityComparerPolyfill<T, TKey>(keySelector, keyComparer ?? EqualityComparer<TKey>.Default);
+        }
+    }
+}
+
+file sealed class KeySelectorEqualityComparerPolyfill<T, TKey>(Func<T?, TKey?> keySelector, IEqualityComparer<TKey> keyComparer) : EqualityComparer<T>
+{
+    public override bool Equals(T? x, T? y) => keyComparer.Equals(keySelector(x), keySelector(y));
+
+    public override int GetHashCode(T obj)
+    {
+        var key = keySelector(obj);
+        return key is null ? 0 : keyComparer.GetHashCode(key);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.FullJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.FullJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2}).cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+
+static partial class PolyfillExtensions
+{
+    public static IEnumerable<(TOuter? Outer, TInner? Inner)> FullJoin<TOuter, TInner, TKey>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, IEqualityComparer<TKey>? comparer = null)
+    {
+        return FullJoin(outer, inner, outerKeySelector, innerKeySelector, static (outer, inner) => (outer, inner), comparer);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.FullJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``0,``1,``3},System.Collections.Generic.IEqualityComparer{``2}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.FullJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``0,``1,``3},System.Collections.Generic.IEqualityComparer{``2}).cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static partial class PolyfillExtensions
+{
+    public static IEnumerable<TResult> FullJoin<TOuter, TInner, TKey, TResult>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter?, TInner?, TResult> resultSelector, IEqualityComparer<TKey>? comparer = null)
+    {
+        if (outer is null)
+        {
+            throw new ArgumentNullException(nameof(outer));
+        }
+
+        if (inner is null)
+        {
+            throw new ArgumentNullException(nameof(inner));
+        }
+
+        if (outerKeySelector is null)
+        {
+            throw new ArgumentNullException(nameof(outerKeySelector));
+        }
+
+        if (innerKeySelector is null)
+        {
+            throw new ArgumentNullException(nameof(innerKeySelector));
+        }
+
+        if (resultSelector is null)
+        {
+            throw new ArgumentNullException(nameof(resultSelector));
+        }
+
+        return FullJoinIterator(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
+    }
+
+    private static IEnumerable<TResult> FullJoinIterator<TOuter, TInner, TKey, TResult>(IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter?, TInner?, TResult> resultSelector, IEqualityComparer<TKey>? comparer)
+    {
+        var innerLookup = inner.ToLookup(innerKeySelector, comparer);
+        var matchedKeys = new HashSet<TKey>(comparer);
+
+        foreach (var outerItem in outer)
+        {
+            var outerKey = outerKeySelector(outerItem);
+            if (outerKey is not null)
+            {
+                var innerGroup = innerLookup[outerKey];
+                using var enumerator = innerGroup.GetEnumerator();
+                if (enumerator.MoveNext())
+                {
+                    matchedKeys.Add(outerKey);
+                    do
+                    {
+                        yield return resultSelector(outerItem, enumerator.Current);
+                    }
+                    while (enumerator.MoveNext());
+
+                    continue;
+                }
+            }
+
+            yield return resultSelector(outerItem, default);
+        }
+
+        foreach (var innerGroup in innerLookup)
+        {
+            if (!matchedKeys.Contains(innerGroup.Key))
+            {
+                foreach (var innerItem in innerGroup)
+                {
+                    yield return resultSelector(default, innerItem);
+                }
+            }
+        }
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.FullJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``0,``1,``3},System.Collections.Generic.IEqualityComparer{``2}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.FullJoin``4(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Func{``0,``1,``3},System.Collections.Generic.IEqualityComparer{``2}).cs
@@ -31,10 +31,13 @@ static partial class PolyfillExtensions
             throw new ArgumentNullException(nameof(resultSelector));
         }
 
-        return FullJoinIterator(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
+        return FullJoinImplementation.FullJoinIterator(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
     }
+}
 
-    private static IEnumerable<TResult> FullJoinIterator<TOuter, TInner, TKey, TResult>(IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter?, TInner?, TResult> resultSelector, IEqualityComparer<TKey>? comparer)
+file static class FullJoinImplementation
+{
+    public static IEnumerable<TResult> FullJoinIterator<TOuter, TInner, TKey, TResult>(IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter?, TInner?, TResult> resultSelector, IEqualityComparer<TKey>? comparer)
     {
         var innerLookup = inner.ToLookup(innerKeySelector, comparer);
         var matchedKeys = new HashSet<TKey>(comparer);

--- a/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.GroupJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.GroupJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2}).cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+static partial class PolyfillExtensions
+{
+    public static IEnumerable<IGrouping<TOuter, TInner>> GroupJoin<TOuter, TInner, TKey>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, IEqualityComparer<TKey>? comparer = null)
+    {
+        return outer.GroupJoin(inner, outerKeySelector, innerKeySelector, static (outer, elements) => (IGrouping<TOuter, TInner>)new GroupJoinGroupingPolyfill<TOuter, TInner>(outer, elements), comparer);
+    }
+}
+
+file sealed class GroupJoinGroupingPolyfill<TKey, TElement>(TKey key, IEnumerable<TElement> elements) : IGrouping<TKey, TElement>
+{
+    public TKey Key => key;
+
+    public IEnumerator<TElement> GetEnumerator() => elements.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.Join``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.Join``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2}).cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static partial class PolyfillExtensions
+{
+    public static IEnumerable<(TOuter Outer, TInner Inner)> Join<TOuter, TInner, TKey>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, IEqualityComparer<TKey>? comparer = null)
+    {
+        return outer.Join(inner, outerKeySelector, innerKeySelector, static (outer, inner) => (outer, inner), comparer);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.LeftJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.LeftJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2}).cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static partial class PolyfillExtensions
+{
+    public static IEnumerable<(TOuter Outer, TInner? Inner)> LeftJoin<TOuter, TInner, TKey>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, IEqualityComparer<TKey>? comparer = null)
+    {
+        if (outer is null)
+        {
+            throw new ArgumentNullException(nameof(outer));
+        }
+
+        if (inner is null)
+        {
+            throw new ArgumentNullException(nameof(inner));
+        }
+
+        if (outerKeySelector is null)
+        {
+            throw new ArgumentNullException(nameof(outerKeySelector));
+        }
+
+        if (innerKeySelector is null)
+        {
+            throw new ArgumentNullException(nameof(innerKeySelector));
+        }
+
+        return LeftJoinTupleIterator(outer, inner, outerKeySelector, innerKeySelector, comparer);
+    }
+
+    private static IEnumerable<(TOuter Outer, TInner? Inner)> LeftJoinTupleIterator<TOuter, TInner, TKey>(IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, IEqualityComparer<TKey>? comparer)
+    {
+        var innerLookup = inner.ToLookup(innerKeySelector, comparer);
+        foreach (var outerItem in outer)
+        {
+            var outerKey = outerKeySelector(outerItem);
+            if (outerKey is not null)
+            {
+                var innerGroup = innerLookup[outerKey];
+                using var enumerator = innerGroup.GetEnumerator();
+                if (enumerator.MoveNext())
+                {
+                    do
+                    {
+                        yield return (outerItem, enumerator.Current);
+                    }
+                    while (enumerator.MoveNext());
+
+                    continue;
+                }
+            }
+
+            yield return (outerItem, default);
+        }
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.LeftJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.LeftJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2}).cs
@@ -26,10 +26,13 @@ static partial class PolyfillExtensions
             throw new ArgumentNullException(nameof(innerKeySelector));
         }
 
-        return LeftJoinTupleIterator(outer, inner, outerKeySelector, innerKeySelector, comparer);
+        return LeftJoinImplementation.LeftJoinIterator(outer, inner, outerKeySelector, innerKeySelector, comparer);
     }
+}
 
-    private static IEnumerable<(TOuter Outer, TInner? Inner)> LeftJoinTupleIterator<TOuter, TInner, TKey>(IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, IEqualityComparer<TKey>? comparer)
+file static class LeftJoinImplementation
+{
+    public static IEnumerable<(TOuter Outer, TInner? Inner)> LeftJoinIterator<TOuter, TInner, TKey>(IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, IEqualityComparer<TKey>? comparer)
     {
         var innerLookup = inner.ToLookup(innerKeySelector, comparer);
         foreach (var outerItem in outer)

--- a/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.RightJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.RightJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2}).cs
@@ -26,10 +26,13 @@ static partial class PolyfillExtensions
             throw new ArgumentNullException(nameof(innerKeySelector));
         }
 
-        return RightJoinTupleIterator(outer, inner, outerKeySelector, innerKeySelector, comparer);
+        return RightJoinImplementation.RightJoinIterator(outer, inner, outerKeySelector, innerKeySelector, comparer);
     }
+}
 
-    private static IEnumerable<(TOuter? Outer, TInner Inner)> RightJoinTupleIterator<TOuter, TInner, TKey>(IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, IEqualityComparer<TKey>? comparer)
+file static class RightJoinImplementation
+{
+    public static IEnumerable<(TOuter? Outer, TInner Inner)> RightJoinIterator<TOuter, TInner, TKey>(IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, IEqualityComparer<TKey>? comparer)
     {
         var outerLookup = outer.ToLookup(outerKeySelector, comparer);
         foreach (var innerItem in inner)

--- a/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.RightJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Linq.Enumerable.RightJoin``3(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``1},System.Func{``0,``2},System.Func{``1,``2},System.Collections.Generic.IEqualityComparer{``2}).cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+static partial class PolyfillExtensions
+{
+    public static IEnumerable<(TOuter? Outer, TInner Inner)> RightJoin<TOuter, TInner, TKey>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, IEqualityComparer<TKey>? comparer = null)
+    {
+        if (outer is null)
+        {
+            throw new ArgumentNullException(nameof(outer));
+        }
+
+        if (inner is null)
+        {
+            throw new ArgumentNullException(nameof(inner));
+        }
+
+        if (outerKeySelector is null)
+        {
+            throw new ArgumentNullException(nameof(outerKeySelector));
+        }
+
+        if (innerKeySelector is null)
+        {
+            throw new ArgumentNullException(nameof(innerKeySelector));
+        }
+
+        return RightJoinTupleIterator(outer, inner, outerKeySelector, innerKeySelector, comparer);
+    }
+
+    private static IEnumerable<(TOuter? Outer, TInner Inner)> RightJoinTupleIterator<TOuter, TInner, TKey>(IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, IEqualityComparer<TKey>? comparer)
+    {
+        var outerLookup = outer.ToLookup(outerKeySelector, comparer);
+        foreach (var innerItem in inner)
+        {
+            var innerKey = innerKeySelector(innerItem);
+            if (innerKey is not null)
+            {
+                var outerGroup = outerLookup[innerKey];
+                using var enumerator = outerGroup.GetEnumerator();
+                if (enumerator.MoveNext())
+                {
+                    do
+                    {
+                        yield return (enumerator.Current, innerItem);
+                    }
+                    while (enumerator.MoveNext());
+
+                    continue;
+                }
+            }
+
+            yield return (default, innerItem);
+        }
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(System.ReadOnlySpan{System.Byte},System.Byte).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(System.ReadOnlySpan{System.Byte},System.Byte).cs
@@ -1,0 +1,17 @@
+partial class PolyfillExtensions
+{
+    extension(System.Security.Cryptography.CryptographicOperations)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
+        public static bool FixedTimeEquals(System.ReadOnlySpan<byte> source, byte value)
+        {
+            var result = 0;
+            for (var i = 0; i < source.Length; i++)
+            {
+                result |= source[i] - value;
+            }
+
+            return result == 0;
+        }
+    }
+}

--- a/Meziantou.Polyfill.Editor/T;System.Net.Mime.MediaTypeNames.Video.cs
+++ b/Meziantou.Polyfill.Editor/T;System.Net.Mime.MediaTypeNames.Video.cs
@@ -1,0 +1,13 @@
+static partial class PolyfillExtensions
+{
+    extension(System.Net.Mime.MediaTypeNames)
+    {
+        public static MediaTypeNamesVideoPolyfill Video => MediaTypeNamesVideoPolyfill.Instance;
+    }
+}
+
+internal sealed class MediaTypeNamesVideoPolyfill
+{
+    public static readonly MediaTypeNamesVideoPolyfill Instance = new();
+    private MediaTypeNamesVideoPolyfill() { }
+}

--- a/Meziantou.Polyfill.Editor/T;System.Security.Cryptography.CryptographicOperations.cs
+++ b/Meziantou.Polyfill.Editor/T;System.Security.Cryptography.CryptographicOperations.cs
@@ -1,0 +1,6 @@
+// when M:System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(System.ReadOnlySpan{System.Byte},System.Byte)
+namespace System.Security.Cryptography;
+
+internal static class CryptographicOperations
+{
+}

--- a/Meziantou.Polyfill.Generator/Program.cs
+++ b/Meziantou.Polyfill.Generator/Program.cs
@@ -639,7 +639,7 @@ static async Task DetectAndAssignVersionsAsync(Polyfill[] polyfills, CSharpCompi
         ("microsoft.netcore.app.ref", "8.0.0", "net8.0", Path.Combine("ref", "net8.0")),
         ("microsoft.netcore.app.ref", "9.0.0", "net9.0", Path.Combine("ref", "net9.0")),
         ("microsoft.netcore.app.ref", "10.0.0", "net10.0", Path.Combine("ref", "net10.0")),
-        ("microsoft.netcore.app.ref", "11.0.0-preview.4.26230.115", "net11.0", Path.Combine("ref", "net11.0")),
+        ("microsoft.netcore.app.ref", "11.0.0-preview.5.26302.115", "net11.0", Path.Combine("ref", "net11.0")),
     };
 
     // Build TFM definitions from known package list

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -241,6 +241,21 @@
       "net10.0",
       "net11.0"
     ],
+    "F:System.Net.Mime.MediaTypeNames.Video.Mp4": [
+      "net11.0"
+    ],
+    "F:System.Net.Mime.MediaTypeNames.Video.Mpeg": [
+      "net11.0"
+    ],
+    "F:System.Net.Mime.MediaTypeNames.Video.Ogg": [
+      "net11.0"
+    ],
+    "F:System.Net.Mime.MediaTypeNames.Video.QuickTime": [
+      "net11.0"
+    ],
+    "F:System.Net.Mime.MediaTypeNames.Video.WebM": [
+      "net11.0"
+    ],
     "M:System.ArgumentException.ThrowIfNullOrEmpty(System.String,System.String)": [
       "net7.0",
       "net8.0",
@@ -903,6 +918,9 @@
       "net8.0",
       "net9.0",
       "net10.0",
+      "net11.0"
+    ],
+    "M:System.Collections.Generic.EqualityComparer\u00601.Create\u0060\u00601(System.Func{\u00600,\u0060\u00600},System.Collections.Generic.IEqualityComparer{\u0060\u00600})": [
       "net11.0"
     ],
     "M:System.Collections.Generic.HashSet\u00601.TrimExcess(System.Int32)": [
@@ -3173,6 +3191,15 @@
       "net10.0",
       "net11.0"
     ],
+    "M:System.Linq.Enumerable.FullJoin\u0060\u00603(System.Collections.Generic.IEnumerable{\u0060\u00600},System.Collections.Generic.IEnumerable{\u0060\u00601},System.Func{\u0060\u00600,\u0060\u00602},System.Func{\u0060\u00601,\u0060\u00602},System.Collections.Generic.IEqualityComparer{\u0060\u00602})": [
+      "net11.0"
+    ],
+    "M:System.Linq.Enumerable.FullJoin\u0060\u00604(System.Collections.Generic.IEnumerable{\u0060\u00600},System.Collections.Generic.IEnumerable{\u0060\u00601},System.Func{\u0060\u00600,\u0060\u00602},System.Func{\u0060\u00601,\u0060\u00602},System.Func{\u0060\u00600,\u0060\u00601,\u0060\u00603},System.Collections.Generic.IEqualityComparer{\u0060\u00602})": [
+      "net11.0"
+    ],
+    "M:System.Linq.Enumerable.GroupJoin\u0060\u00603(System.Collections.Generic.IEnumerable{\u0060\u00600},System.Collections.Generic.IEnumerable{\u0060\u00601},System.Func{\u0060\u00600,\u0060\u00602},System.Func{\u0060\u00601,\u0060\u00602},System.Collections.Generic.IEqualityComparer{\u0060\u00602})": [
+      "net11.0"
+    ],
     "M:System.Linq.Enumerable.Index\u0060\u00601(System.Collections.Generic.IEnumerable{\u0060\u00600})": [
       "net9.0",
       "net10.0",
@@ -3196,6 +3223,12 @@
       "net8.0",
       "net9.0",
       "net10.0",
+      "net11.0"
+    ],
+    "M:System.Linq.Enumerable.Join\u0060\u00603(System.Collections.Generic.IEnumerable{\u0060\u00600},System.Collections.Generic.IEnumerable{\u0060\u00601},System.Func{\u0060\u00600,\u0060\u00602},System.Func{\u0060\u00601,\u0060\u00602},System.Collections.Generic.IEqualityComparer{\u0060\u00602})": [
+      "net11.0"
+    ],
+    "M:System.Linq.Enumerable.LeftJoin\u0060\u00603(System.Collections.Generic.IEnumerable{\u0060\u00600},System.Collections.Generic.IEnumerable{\u0060\u00601},System.Func{\u0060\u00600,\u0060\u00602},System.Func{\u0060\u00601,\u0060\u00602},System.Collections.Generic.IEqualityComparer{\u0060\u00602})": [
       "net11.0"
     ],
     "M:System.Linq.Enumerable.LeftJoin\u0060\u00604(System.Collections.Generic.IEnumerable{\u0060\u00600},System.Collections.Generic.IEnumerable{\u0060\u00601},System.Func{\u0060\u00600,\u0060\u00602},System.Func{\u0060\u00601,\u0060\u00602},System.Func{\u0060\u00600,\u0060\u00601,\u0060\u00603})": [
@@ -3264,6 +3297,9 @@
       "net8.0",
       "net9.0",
       "net10.0",
+      "net11.0"
+    ],
+    "M:System.Linq.Enumerable.RightJoin\u0060\u00603(System.Collections.Generic.IEnumerable{\u0060\u00600},System.Collections.Generic.IEnumerable{\u0060\u00601},System.Func{\u0060\u00600,\u0060\u00602},System.Func{\u0060\u00601,\u0060\u00602},System.Collections.Generic.IEqualityComparer{\u0060\u00602})": [
       "net11.0"
     ],
     "M:System.Linq.Enumerable.RightJoin\u0060\u00604(System.Collections.Generic.IEnumerable{\u0060\u00600},System.Collections.Generic.IEnumerable{\u0060\u00601},System.Func{\u0060\u00600,\u0060\u00602},System.Func{\u0060\u00601,\u0060\u00602},System.Func{\u0060\u00600,\u0060\u00601,\u0060\u00603})": [
@@ -4145,6 +4181,9 @@
       "net8.0",
       "net9.0",
       "net10.0",
+      "net11.0"
+    ],
+    "M:System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(System.ReadOnlySpan{System.Byte},System.Byte)": [
       "net11.0"
     ],
     "M:System.Security.Cryptography.IncrementalHash.AppendData(System.ReadOnlySpan{System.Byte})": [
@@ -6401,8 +6440,7 @@
     ],
     "T:System.ITupleInternal": [
       "net472",
-      "net48",
-      "net11.0"
+      "net48"
     ],
     "T:System.Index": [
       "netstandard2.1",
@@ -6432,6 +6470,9 @@
       "net8.0",
       "net9.0",
       "net10.0",
+      "net11.0"
+    ],
+    "T:System.Net.Mime.MediaTypeNames.Video": [
       "net11.0"
     ],
     "T:System.Range": [
@@ -6652,6 +6693,15 @@
       "net11.0"
     ],
     "T:System.Runtime.Versioning.UnsupportedOSPlatformGuardAttribute": [
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0",
+      "net11.0"
+    ],
+    "T:System.Security.Cryptography.CryptographicOperations": [
+      "netstandard2.1",
       "net6.0",
       "net7.0",
       "net8.0",

--- a/Meziantou.Polyfill.SourceGenerator.Tests/SourceGeneratorTests.cs
+++ b/Meziantou.Polyfill.SourceGenerator.Tests/SourceGeneratorTests.cs
@@ -12,7 +12,7 @@ namespace Meziantou.Polyfill.SourceGenerator.Tests;
 
 public sealed class SourceGeneratorTests
 {
-    private const string LatestDotnetPackageVersion = "11.0.0-preview.4.26230.115";
+    private const string LatestDotnetPackageVersion = "11.0.0-preview.5.26302.115";
     private const string LatestDotnetTfm = "net11.0";
 
     [Fact]

--- a/Meziantou.Polyfill.Tests/SystemCollectionsGenericTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemCollectionsGenericTests.cs
@@ -35,6 +35,18 @@ public class SystemCollectionsGenericTests
     }
 
     [Fact]
+    public void EqualityComparer_Create_KeySelector()
+    {
+        var comparer = EqualityComparer<string>.Create(value => value?.Length);
+
+        Assert.True(comparer.Equals("test", "TEST"));
+        Assert.False(comparer.Equals("test", "other"));
+        Assert.Equal(comparer.GetHashCode("test"), comparer.GetHashCode("TEST"));
+        Assert.Equal(0, comparer.GetHashCode(null!));
+        Assert.Throws<ArgumentNullException>(() => EqualityComparer<string>.Create((Func<string?, int?>)null!));
+    }
+
+    [Fact]
     public void System_Collections_Generic_KeyValuePair_2_Deconstruct()
     {
         var data = new KeyValuePair<string, object>("test", 2);

--- a/Meziantou.Polyfill.Tests/SystemLinqTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemLinqTests.cs
@@ -281,4 +281,61 @@ public class SystemLinqTests
         Assert.Equal([("a", "A"), ("none", "b")], result);
     }
 
+    [Fact]
+    public void Enumerable_FullJoin()
+    {
+        var result = new[] { "a1", "a2", "b" }.FullJoin(new[] { "a3", "c1", "c2" }, value => value[0], value => value[0]);
+
+        Assert.Equal([("a1", "a3"), ("a2", "a3"), ("b", null), (null, "c1"), (null, "c2")], result);
+    }
+
+    [Fact]
+    public void Enumerable_FullJoin_ResultSelector_Comparer()
+    {
+        var result = new[] { "A", "b" }.FullJoin(new[] { "a", "C" }, outer => outer, inner => inner, (outer, inner) => $"{outer ?? "none"}:{inner ?? "none"}", StringComparer.OrdinalIgnoreCase);
+
+        Assert.Equal(["A:a", "b:none", "none:C"], result);
+    }
+
+    [Fact]
+    public void Enumerable_FullJoin_NullKeysDoNotMatch()
+    {
+        var result = new string?[] { null }.FullJoin(new string?[] { null }, value => value, value => value);
+
+        Assert.Equal([(null, null), (null, null)], result);
+    }
+
+    [Fact]
+    public void Enumerable_GroupJoin_TupleJoin()
+    {
+        var result = new[] { "a1", "a2", "b" }.GroupJoin(new[] { "a3", "c" }, value => value[0], value => value[0]);
+
+        Assert.Equal(["a1", "a2", "b"], result.Select(group => group.Key));
+        Assert.Equal([["a3"], ["a3"], []], result.Select(group => group.ToArray()));
+    }
+
+    [Fact]
+    public void Enumerable_Join_TupleJoin()
+    {
+        var result = new[] { "a1", "a2", "b" }.Join(new[] { "a3", "c" }, value => value[0], value => value[0]);
+
+        Assert.Equal([("a1", "a3"), ("a2", "a3")], result);
+    }
+
+    [Fact]
+    public void Enumerable_LeftJoin_TupleJoin()
+    {
+        var result = new[] { "a", "b" }.LeftJoin(new[] { "A" }, outer => outer, inner => inner, comparer: StringComparer.OrdinalIgnoreCase);
+
+        Assert.Equal([("a", "A"), ("b", null)], result);
+    }
+
+    [Fact]
+    public void Enumerable_RightJoin_TupleJoin()
+    {
+        var result = new[] { "a" }.RightJoin(new[] { "A", "b" }, outer => outer, inner => inner, comparer: StringComparer.OrdinalIgnoreCase);
+
+        Assert.Equal([("a", "A"), (null, "b")], result);
+    }
+
 }

--- a/Meziantou.Polyfill.Tests/SystemNetMimeTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemNetMimeTests.cs
@@ -52,5 +52,12 @@ public class SystemNetMimeTests
         Assert.Equal("text/markdown", MediaTypeNames.Text.Markdown);
         Assert.Equal("text/rtf", MediaTypeNames.Text.Rtf);
         Assert.Equal("text/event-stream", MediaTypeNames.Text.EventStream);
+
+        // Video
+        Assert.Equal("video/mp4", MediaTypeNames.Video.Mp4);
+        Assert.Equal("video/mpeg", MediaTypeNames.Video.Mpeg);
+        Assert.Equal("video/ogg", MediaTypeNames.Video.Ogg);
+        Assert.Equal("video/quicktime", MediaTypeNames.Video.QuickTime);
+        Assert.Equal("video/webm", MediaTypeNames.Video.WebM);
     }
 }

--- a/Meziantou.Polyfill.Tests/SystemSecurityCryptographyTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemSecurityCryptographyTests.cs
@@ -19,6 +19,14 @@ namespace Meziantou.Polyfill.Tests;
 public class SystemSecurityCryptographyTests
 {
     [Fact]
+    public void CryptographicOperations_FixedTimeEquals_Value()
+    {
+        Assert.True(CryptographicOperations.FixedTimeEquals(ReadOnlySpan<byte>.Empty, (byte)42));
+        Assert.True(CryptographicOperations.FixedTimeEquals([42, 42, 42], (byte)42));
+        Assert.False(CryptographicOperations.FixedTimeEquals([42, 41, 42], (byte)42));
+    }
+
+    [Fact]
     public void SHA256_HashData_ReadOnlySpan()
     {
         // Test with empty span - SHA256 of empty string

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.150</Version>
+    <Version>1.0.151</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The filtering logic works as follows:
 
 <!-- begin_polyfills -->
 
-### Types (89)
+### Types (91)
 
 - `System.Buffers.SearchValues`
 - `System.Buffers.SearchValues<T> where T : System.IEquatable<T>?`
@@ -101,6 +101,7 @@ The filtering logic works as follows:
 - `System.Net.Http.ReadOnlyMemoryContent`
 - `System.Net.Mime.MediaTypeNames.Font`
 - `System.Net.Mime.MediaTypeNames.Multipart`
+- `System.Net.Mime.MediaTypeNames.Video`
 - `System.Range`
 - `System.Reflection.NullabilityInfo`
 - `System.Reflection.NullabilityInfoContext`
@@ -132,6 +133,7 @@ The filtering logic works as follows:
 - `System.Runtime.Versioning.TargetPlatformAttribute`
 - `System.Runtime.Versioning.UnsupportedOSPlatformAttribute`
 - `System.Runtime.Versioning.UnsupportedOSPlatformGuardAttribute`
+- `System.Security.Cryptography.CryptographicOperations`
 - `System.Text.RegularExpressions.Regex.ValueMatchEnumerator`
 - `System.Text.RegularExpressions.Regex.ValueSplitEnumerator`
 - `System.Text.RegularExpressions.ValueMatch`
@@ -152,7 +154,7 @@ The filtering logic works as follows:
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (1045)
+### Methods (1053)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -254,6 +256,7 @@ The filtering logic works as follows:
 - `System.Collections.Generic.Dictionary<TKey, TValue>.TrimExcess(System.Int32 capacity)`
 - `System.Collections.Generic.Dictionary<TKey, TValue>.TryAdd(TKey key, TValue value)`
 - `System.Collections.Generic.EqualityComparer<T>.Create(System.Func<T?, T?, System.Boolean> equals, [System.Func<T, System.Int32>? getHashCode = null])`
+- `System.Collections.Generic.EqualityComparer<T>.Create<TKey>(System.Func<T?, TKey?> keySelector, [System.Collections.Generic.IEqualityComparer<TKey>? keyComparer = null])`
 - `System.Collections.Generic.HashSet<T>.TrimExcess(System.Int32 capacity)`
 - `System.Collections.Generic.KeyValuePair.Create<TKey, TValue>(TKey key, TValue value)`
 - `System.Collections.Generic.KeyValuePair<TKey, TValue>.Deconstruct(out TKey key, out TValue value)`
@@ -678,10 +681,15 @@ The filtering logic works as follows:
 - `System.Linq.Enumerable.CountBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, [System.Collections.Generic.IEqualityComparer<TKey>? keyComparer = null]) where TKey : notnull`
 - `System.Linq.Enumerable.DistinctBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector)`
 - `System.Linq.Enumerable.DistinctBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer)`
+- `System.Linq.Enumerable.FullJoin<TOuter, TInner, TKey>(this System.Collections.Generic.IEnumerable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Func<TOuter, TKey> outerKeySelector, System.Func<TInner, TKey> innerKeySelector, [System.Collections.Generic.IEqualityComparer<TKey>? comparer = null])`
+- `System.Linq.Enumerable.FullJoin<TOuter, TInner, TKey, TResult>(this System.Collections.Generic.IEnumerable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Func<TOuter, TKey> outerKeySelector, System.Func<TInner, TKey> innerKeySelector, System.Func<TOuter?, TInner?, TResult> resultSelector, [System.Collections.Generic.IEqualityComparer<TKey>? comparer = null])`
+- `System.Linq.Enumerable.GroupJoin<TOuter, TInner, TKey>(this System.Collections.Generic.IEnumerable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Func<TOuter, TKey> outerKeySelector, System.Func<TInner, TKey> innerKeySelector, [System.Collections.Generic.IEqualityComparer<TKey>? comparer = null])`
 - `System.Linq.Enumerable.Index<TSource>(this System.Collections.Generic.IEnumerable<TSource> source)`
 - `System.Linq.Enumerable.InfiniteSequence<T>(T start, T step) where T : System.Numerics.IAdditionOperators<T, T, T>`
 - `System.Linq.Enumerable.IntersectBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> first, System.Collections.Generic.IEnumerable<TKey> second, System.Func<TSource, TKey> keySelector)`
 - `System.Linq.Enumerable.IntersectBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> first, System.Collections.Generic.IEnumerable<TKey> second, System.Func<TSource, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer)`
+- `System.Linq.Enumerable.Join<TOuter, TInner, TKey>(this System.Collections.Generic.IEnumerable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Func<TOuter, TKey> outerKeySelector, System.Func<TInner, TKey> innerKeySelector, [System.Collections.Generic.IEqualityComparer<TKey>? comparer = null])`
+- `System.Linq.Enumerable.LeftJoin<TOuter, TInner, TKey>(this System.Collections.Generic.IEnumerable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Func<TOuter, TKey> outerKeySelector, System.Func<TInner, TKey> innerKeySelector, [System.Collections.Generic.IEqualityComparer<TKey>? comparer = null])`
 - `System.Linq.Enumerable.LeftJoin<TOuter, TInner, TKey, TResult>(this System.Collections.Generic.IEnumerable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Func<TOuter, TKey> outerKeySelector, System.Func<TInner, TKey> innerKeySelector, System.Func<TOuter, TInner?, TResult> resultSelector)`
 - `System.Linq.Enumerable.LeftJoin<TOuter, TInner, TKey, TResult>(this System.Collections.Generic.IEnumerable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Func<TOuter, TKey> outerKeySelector, System.Func<TInner, TKey> innerKeySelector, System.Func<TOuter, TInner?, TResult> resultSelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer)`
 - `System.Linq.Enumerable.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector)`
@@ -692,6 +700,7 @@ The filtering logic works as follows:
 - `System.Linq.Enumerable.OrderDescending<T>(this System.Collections.Generic.IEnumerable<T> source, System.Collections.Generic.IComparer<T>? comparer)`
 - `System.Linq.Enumerable.Order<T>(this System.Collections.Generic.IEnumerable<T> source)`
 - `System.Linq.Enumerable.Order<T>(this System.Collections.Generic.IEnumerable<T> source, System.Collections.Generic.IComparer<T>? comparer)`
+- `System.Linq.Enumerable.RightJoin<TOuter, TInner, TKey>(this System.Collections.Generic.IEnumerable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Func<TOuter, TKey> outerKeySelector, System.Func<TInner, TKey> innerKeySelector, [System.Collections.Generic.IEqualityComparer<TKey>? comparer = null])`
 - `System.Linq.Enumerable.RightJoin<TOuter, TInner, TKey, TResult>(this System.Collections.Generic.IEnumerable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Func<TOuter, TKey> outerKeySelector, System.Func<TInner, TKey> innerKeySelector, System.Func<TOuter?, TInner, TResult> resultSelector)`
 - `System.Linq.Enumerable.RightJoin<TOuter, TInner, TKey, TResult>(this System.Collections.Generic.IEnumerable<TOuter> outer, System.Collections.Generic.IEnumerable<TInner> inner, System.Func<TOuter, TKey> outerKeySelector, System.Func<TInner, TKey> innerKeySelector, System.Func<TOuter?, TInner, TResult> resultSelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer)`
 - `System.Linq.Enumerable.Sequence<T>(T start, T endInclusive, T step) where T : System.Numerics.INumber<T>`
@@ -841,6 +850,7 @@ The filtering logic works as follows:
 - `System.SByte.TryParse(System.ReadOnlySpan<System.Char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.SByte result)`
 - `System.SByte.TryParse(System.ReadOnlySpan<System.Char> s, System.IFormatProvider? provider, out System.SByte result)`
 - `System.SByte.TryParse(System.ReadOnlySpan<System.Char> s, out System.SByte result)`
+- `System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(System.ReadOnlySpan<System.Byte> source, System.Byte value)`
 - `System.Security.Cryptography.IncrementalHash.AppendData(System.ReadOnlySpan<System.Byte> data)`
 - `System.Security.Cryptography.MD5.HashData(System.ReadOnlySpan<System.Byte> source)`
 - `System.Security.Cryptography.RandomNumberGenerator.Fill(System.Span<System.Byte> data)`
@@ -1200,7 +1210,7 @@ The filtering logic works as follows:
 - `System.Xml.Linq.XNode.ReadFromAsync(System.Xml.XmlReader reader, System.Threading.CancellationToken cancellationToken)`
 - `System.Xml.Linq.XNode.WriteToAsync(System.Xml.XmlWriter writer, System.Threading.CancellationToken cancellationToken)`
 
-### Properties (200)
+### Properties (205)
 
 - `System.DateTimeOffset.UnixEpoch`
 - `System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.CSharp = "C#"`
@@ -1253,6 +1263,11 @@ The filtering logic works as follows:
 - `System.Net.Mime.MediaTypeNames.Text.JavaScript = "text/javascript"`
 - `System.Net.Mime.MediaTypeNames.Text.Markdown = "text/markdown"`
 - `System.Net.Mime.MediaTypeNames.Text.Rtf = "text/rtf"`
+- `System.Net.Mime.MediaTypeNames.Video.Mp4 = "video/mp4"`
+- `System.Net.Mime.MediaTypeNames.Video.Mpeg = "video/mpeg"`
+- `System.Net.Mime.MediaTypeNames.Video.Ogg = "video/ogg"`
+- `System.Net.Mime.MediaTypeNames.Video.QuickTime = "video/quicktime"`
+- `System.Net.Mime.MediaTypeNames.Video.WebM = "video/webm"`
 - `System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute.RefStructs = "RefStructs"`
 - `System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute.RequiredMembers = "RequiredMembers"`
 - `System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute.CallConvs`


### PR DESCRIPTION
## Summary
- Update the generator and supported-version metadata for the latest .NET 11 preview
- Add polyfills for new `MediaTypeNames.Video`, `EqualityComparer<T>.Create`, LINQ join overloads, and `CryptographicOperations.FixedTimeEquals`
- Refresh the README polyfill inventory and add coverage in unit tests

## Testing
- Not run (not requested)