### PR TITLE
Fix infinite recursion in `HttpContent.CopyToAsync(Stream, CancellationToken)`

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.Net.Http.HttpContent.CopyToAsync(System.IO.Stream,System.Threading.CancellationToken).cs
+++ b/Meziantou.Polyfill.Editor/M;System.Net.Http.HttpContent.CopyToAsync(System.IO.Stream,System.Threading.CancellationToken).cs
@@ -5,5 +5,5 @@ using System.Threading.Tasks;
 
 static partial class PolyfillExtensions
 {
-    public static Task CopyToAsync(this HttpContent target, Stream stream, CancellationToken cancellationToken) => target.CopyToAsync(stream, cancellationToken);
+    public static Task CopyToAsync(this HttpContent target, Stream stream, CancellationToken cancellationToken) => target.CopyToAsync(stream, null, cancellationToken);
 }


### PR DESCRIPTION
The polyfill body called `target.CopyToAsync(stream, cancellationToken)`, which resolves back to the extension method itself, causing infinite recursion and a `StackOverflowException` at runtime.

The fix delegates to `CopyToAsync(Stream, TransportContext, CancellationToken)` with `null` for context.

Fixes #258