### PR TITLE
Optimize ordinal char StartsWith/EndsWith polyfills

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.String.EndsWith(System.Char,System.StringComparison).cs
+++ b/Meziantou.Polyfill.Editor/M;System.String.EndsWith(System.Char,System.StringComparison).cs
@@ -5,6 +5,9 @@ static partial class PolyfillExtensions
 {
     public static bool EndsWith(this string target, char value, System.StringComparison comparisonType)
     {
+        if (comparisonType == System.StringComparison.Ordinal)
+            return target.Length > 0 && target[target.Length - 1] == value;
+
         return target.EndsWith(value.ToString(), comparisonType);
     }
 }

--- a/Meziantou.Polyfill.Editor/M;System.String.StartsWith(System.Char,System.StringComparison).cs
+++ b/Meziantou.Polyfill.Editor/M;System.String.StartsWith(System.Char,System.StringComparison).cs
@@ -5,6 +5,9 @@ static partial class PolyfillExtensions
 {
     public static bool StartsWith(this string target, char value, System.StringComparison comparisonType)
     {
+        if (comparisonType == System.StringComparison.Ordinal)
+            return target.Length > 0 && target[0] == value;
+
         return target.StartsWith(value.ToString(), comparisonType);
     }
 }

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.154</Version>
+    <Version>1.0.155</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 


### PR DESCRIPTION
## Why
`StartsWith(char, StringComparison)` and `EndsWith(char, StringComparison)` in the editor polyfills always allocated via `value.ToString()`, including for `StringComparison.Ordinal`. For ordinal comparison, this allocation is unnecessary and avoidable.

## What changed
- Added an allocation-free fast path for `StringComparison.Ordinal` in:
  - `M;System.String.StartsWith(System.Char,System.StringComparison).cs`
  - `M;System.String.EndsWith(System.Char,System.StringComparison).cs`
- Kept existing non-ordinal behavior unchanged (still delegates to string-based comparison path).
- Bumped package version patch number in `Meziantou.Polyfill.csproj` to `1.0.155`.

## Notes for reviewers
- Similar `char`-based `IndexOf`/`LastIndexOf` StringComparison polyfills already had ordinal fast paths, so this PR aligns `StartsWith`/`EndsWith` with that pattern.

## Validation
- `dotnet run --project ./Meziantou.Polyfill.Generator/Meziantou.Polyfill.Generator.csproj`
- `dotnet build` (0 warnings)
- `dotnet test -f net11.0 --no-build`
- Full `dotnet test` in this environment aborts for net4x targets because `mono` is not installed.