### PR TITLE
Add opt-in Debug.g.cs skip reasons

### DIFF
--- a/Meziantou.Polyfill.Generator/Program.cs
+++ b/Meziantou.Polyfill.Generator/Program.cs
@@ -188,7 +188,7 @@ async Task GenerateMembers()
         throw new InvalidOperationException($"Feature bit count ({totalFeatureBits}) exceeds 64; widen _features.");
 
     // Build the ordered table of entries plus the flat conditional/declared arrays.
-    var conditionals = new List<(byte FieldIndex, ulong Mask)>();
+    var conditionals = new List<(byte FieldIndex, ulong Mask, string DocId)>();
     var declaredDocIds = new List<string>();
     var tableEntries = new List<(Polyfill Polyfill, sbyte ProvidesFeatureBit, ushort CondStart, byte CondCount, ushort DeclStart, byte DeclCount, ulong RequiredFeatures)>();
 
@@ -207,7 +207,7 @@ async Task GenerateMembers()
         foreach (var member in polyfill.PolyfillData.ConditionalMembers)
         {
             var dep = polyfills.Single(p => p.TypeName == member);
-            conditionals.Add(((byte)(dep.Index / 64), dep.CSharpFieldBitMask));
+            conditionals.Add(((byte)(dep.Index / 64), dep.CSharpFieldBitMask, dep.TypeName));
             checked
             { condCount++; }
         }
@@ -269,6 +269,7 @@ async Task GenerateMembers()
     sb.AppendLine("private readonly PolyfillOptions _options;");
     sb.AppendLine("private readonly ulong _features;");
     sb.AppendLine("private readonly string _sourcePrefix;");
+    sb.AppendLine("private readonly string[]? _skipReasons;");
 
     sb.AppendLine("public Members(Compilation compilation, PolyfillOptions options)");
     sb.AppendLine("{");
@@ -309,10 +310,15 @@ async Task GenerateMembers()
     sb.AppendLine("    var entries = PolyfillEntries.Entries;");
     sb.AppendLine("    var conditionals = PolyfillEntries.Conditionals;");
     sb.AppendLine("    var declared = PolyfillEntries.DeclaredDocIds;");
+    sb.AppendLine("    string[]? skipReasons = options.GenerateDebugFile ? new string[entries.Length] : null;");
     sb.AppendLine("    for (var idx = 0; idx < entries.Length; idx++)");
     sb.AppendLine("    {");
     sb.AppendLine("        ref readonly var entry = ref entries[idx];");
-    sb.AppendLine("        if ((feat & entry.RequiredFeatures) != entry.RequiredFeatures) continue;");
+    sb.AppendLine("        if ((feat & entry.RequiredFeatures) != entry.RequiredFeatures)");
+    sb.AppendLine("        {");
+    sb.AppendLine("            skipReasons?[idx] = GetMissingFeaturesReason(feat, entry.RequiredFeatures);");
+    sb.AppendLine("            continue;");
+    sb.AppendLine("        }");
     sb.AppendLine("        if (entry.ConditionalCount > 0)");
     sb.AppendLine("        {");
     sb.AppendLine("            var any = false;");
@@ -322,16 +328,31 @@ async Task GenerateMembers()
     sb.AppendLine("                ref readonly var c = ref conditionals[j];");
     sb.AppendLine("                if ((bits[c.FieldIndex] & c.Mask) != 0uL) { any = true; break; }");
     sb.AppendLine("            }");
-    sb.AppendLine("            if (!any) continue;");
+    sb.AppendLine("            if (!any)");
+    sb.AppendLine("            {");
+    sb.AppendLine("                skipReasons?[idx] = GetConditionalDependenciesReason(bits, conditionals, entry.ConditionalStart, entry.ConditionalCount);");
+    sb.AppendLine("                continue;");
+    sb.AppendLine("            }");
     sb.AppendLine("        }");
-    sb.AppendLine("        if (!IncludeMember(includeContext, entry.DocId)) continue;");
+    sb.AppendLine("        var skipReason = GetMemberSkipReason(includeContext, entry.DocId);");
+    sb.AppendLine("        if (skipReason is not null)");
+    sb.AppendLine("        {");
+    sb.AppendLine("            skipReasons?[idx] = skipReason;");
+    sb.AppendLine("            continue;");
+    sb.AppendLine("        }");
     sb.AppendLine("        if (entry.DeclaredCount > 0)");
     sb.AppendLine("        {");
     sb.AppendLine("            var allOk = true;");
     sb.AppendLine("            var declEnd = entry.DeclaredStart + entry.DeclaredCount;");
     sb.AppendLine("            for (var j = (int)entry.DeclaredStart; j < declEnd; j++)");
     sb.AppendLine("            {");
-    sb.AppendLine("                if (!IncludeMember(includeContext, declared[j])) { allOk = false; break; }");
+    sb.AppendLine("                var declaredSkipReason = GetMemberSkipReason(includeContext, declared[j]);");
+    sb.AppendLine("                if (declaredSkipReason is not null)");
+    sb.AppendLine("                {");
+    sb.AppendLine("                    allOk = false;");
+    sb.AppendLine("                    skipReasons?[idx] = \"declared member \" + declared[j] + \": \" + declaredSkipReason;");
+    sb.AppendLine("                    break;");
+    sb.AppendLine("                }");
     sb.AppendLine("            }");
     sb.AppendLine("            if (!allOk) continue;");
     sb.AppendLine("        }");
@@ -347,12 +368,13 @@ async Task GenerateMembers()
         sb.AppendLine($"    _bits{i} = bits[{i}];");
     }
     sb.AppendLine("    _features = feat;");
+    sb.AppendLine("    _skipReasons = skipReasons;");
     sb.AppendLine("}");
 
     sb.AppendLine("public override int GetHashCode()");
     sb.AppendLine("{");
-    sb.AppendLine("    var hash = _bits0.GetHashCode();");
-    for (var i = 1; i < fieldCount; i++)
+    sb.AppendLine("    var hash = _options.GetHashCode();");
+    for (var i = 0; i < fieldCount; i++)
     {
         sb.AppendLine($"    hash = hash * 23 + _bits{i}.GetHashCode();");
     }
@@ -361,8 +383,8 @@ async Task GenerateMembers()
     sb.AppendLine("}");
 
     sb.AppendLine("public override bool Equals(object? obj) => obj is Members other && Equals(other);");
-    sb.Append("public bool Equals(Members other) => _bits0 == other._bits0");
-    for (var i = 1; i < fieldCount; i++)
+    sb.Append("public bool Equals(Members other) => _options.Equals(other._options)");
+    for (var i = 0; i < fieldCount; i++)
     {
         sb.Append($"  && _bits{i} == other._bits{i}");
     }
@@ -374,6 +396,9 @@ async Task GenerateMembers()
         sb.Append($" || _bits{i} != 0");
     }
     sb.AppendLine(";");
+
+    sb.AppendLine("public bool GenerateDebugFile => _options.GenerateDebugFile;");
+    sb.AppendLine();
 
 
     sb.AppendLine("public void AddSources(SourceProductionContext context)");
@@ -391,6 +416,10 @@ async Task GenerateMembers()
     }
     sb.AppendLine("}");
 
+    var entryIndexByTypeName = tableEntries
+        .Select((Entry, Index) => (Entry.Polyfill.TypeName, Index))
+        .ToDictionary(item => item.TypeName, item => item.Index, StringComparer.Ordinal);
+
     sb.AppendLine("public string DumpAsCSharpComment()");
     sb.AppendLine("{");
     sb.AppendLine("    var sb = new StringBuilder();");
@@ -404,9 +433,63 @@ async Task GenerateMembers()
     sb.AppendLine("    sb.AppendLine(\"//\");");
     foreach (var polyfill in polyfills)
     {
-        sb.AppendLine($"    sb.AppendLine(\"// {polyfill.TypeName}: \" + (({polyfill.CSharpFieldName} & {polyfill.CSharpFieldBitMask}ul) == {polyfill.CSharpFieldBitMask}ul));");
+        var entryIndex = entryIndexByTypeName[polyfill.TypeName];
+        sb.AppendLine($"    AppendPolyfillDebugLine(sb, \"{EscapeStringLiteral(polyfill.TypeName)}\", ({polyfill.CSharpFieldName} & {polyfill.CSharpFieldBitMask}ul) == {polyfill.CSharpFieldBitMask}ul, {entryIndex});");
     }
 
+    sb.AppendLine("    return sb.ToString();");
+    sb.AppendLine("}");
+    sb.AppendLine();
+    sb.AppendLine("private void AppendPolyfillDebugLine(StringBuilder sb, string documentationId, bool isGenerated, int entryIndex)");
+    sb.AppendLine("{");
+    sb.AppendLine("    sb.Append(\"// \");");
+    sb.AppendLine("    sb.Append(documentationId);");
+    sb.AppendLine("    sb.Append(\": \");");
+    sb.AppendLine("    sb.Append(isGenerated);");
+    sb.AppendLine("    if (!isGenerated && _skipReasons is not null && entryIndex >= 0 && entryIndex < _skipReasons.Length)");
+    sb.AppendLine("    {");
+    sb.AppendLine("        var skipReason = _skipReasons[entryIndex];");
+    sb.AppendLine("        if (!string.IsNullOrEmpty(skipReason))");
+    sb.AppendLine("        {");
+    sb.AppendLine("            sb.Append(\" (\");");
+    sb.AppendLine("            sb.Append(skipReason);");
+    sb.AppendLine("            sb.Append(')');");
+    sb.AppendLine("        }");
+    sb.AppendLine("    }");
+    sb.AppendLine("    sb.AppendLine();");
+    sb.AppendLine("}");
+    sb.AppendLine();
+    sb.AppendLine("private static string GetMissingFeaturesReason(ulong features, ulong requiredFeatures)");
+    sb.AppendLine("{");
+    sb.AppendLine("    var sb = new StringBuilder(\"missing required features: \");");
+    sb.AppendLine("    var separator = \"\";");
+    sb.AppendLine("    foreach (var feature in PolyfillDebugData.Features)");
+    sb.AppendLine("    {");
+    sb.AppendLine("        if ((requiredFeatures & feature.Mask) != 0uL && (features & feature.Mask) == 0uL)");
+    sb.AppendLine("        {");
+    sb.AppendLine("            sb.Append(separator);");
+    sb.AppendLine("            sb.Append(feature.Name);");
+    sb.AppendLine("            separator = \", \";");
+    sb.AppendLine("        }");
+    sb.AppendLine("    }");
+    sb.AppendLine("    return sb.ToString();");
+    sb.AppendLine("}");
+    sb.AppendLine();
+    sb.AppendLine("private static string GetConditionalDependenciesReason(ReadOnlySpan<ulong> bits, ConditionalCheck[] conditionals, ushort start, byte count)");
+    sb.AppendLine("{");
+    sb.AppendLine("    var sb = new StringBuilder(\"conditional dependencies not generated: \");");
+    sb.AppendLine("    var separator = \"\";");
+    sb.AppendLine("    var end = start + count;");
+    sb.AppendLine("    for (var i = (int)start; i < end; i++)");
+    sb.AppendLine("    {");
+    sb.AppendLine("        ref readonly var conditional = ref conditionals[i];");
+    sb.AppendLine("        if ((bits[conditional.FieldIndex] & conditional.Mask) == 0uL)");
+    sb.AppendLine("        {");
+    sb.AppendLine("            sb.Append(separator);");
+    sb.AppendLine("            sb.Append(PolyfillDebugData.ConditionalDocIds[i]);");
+    sb.AppendLine("            separator = \", \";");
+    sb.AppendLine("        }");
+    sb.AppendLine("    }");
     sb.AppendLine("    return sb.ToString();");
     sb.AppendLine("}");
 
@@ -485,6 +568,43 @@ async Task GenerateMembers()
         sb.AppendLine($"        \"{EscapeStringLiteral(d)}\",");
     }
     sb.AppendLine("    };");
+    sb.AppendLine("}");
+
+    sb.AppendLine();
+    sb.AppendLine("file static class PolyfillDebugData");
+    sb.AppendLine("{");
+    sb.AppendLine("    public static readonly string[] ConditionalDocIds = new string[]");
+    sb.AppendLine("    {");
+    foreach (var c in conditionals)
+    {
+        sb.AppendLine($"        \"{EscapeStringLiteral(c.DocId)}\",");
+    }
+    sb.AppendLine("    };");
+    sb.AppendLine();
+    sb.AppendLine("    public static readonly PolyfillFeature[] Features = new PolyfillFeature[]");
+    sb.AppendLine("    {");
+    sb.AppendLine($"        new PolyfillFeature({1uL << FeatureBitExtensions}uL, \"CSharp14ExtensionMembers\"),");
+    sb.AppendLine($"        new PolyfillFeature({1uL << FeatureBitUnsafe}uL, \"Unsafe\"),");
+    sb.AppendLine($"        new PolyfillFeature({1uL << FeatureBitAllowsRefStruct}uL, \"AllowsRefStruct\"),");
+    foreach (var requiredType in requiredTypes)
+    {
+        var bitMask = 1uL << featureBitForType[requiredType.TypeName];
+        sb.AppendLine($"        new PolyfillFeature({bitMask}uL, \"T:{EscapeStringLiteral(requiredType.TypeName)}\"),");
+    }
+    sb.AppendLine("    };");
+    sb.AppendLine("}");
+
+    sb.AppendLine();
+    sb.AppendLine("file readonly struct PolyfillFeature");
+    sb.AppendLine("{");
+    sb.AppendLine("    public readonly ulong Mask;");
+    sb.AppendLine("    public readonly string Name;");
+    sb.AppendLine();
+    sb.AppendLine("    public PolyfillFeature(ulong mask, string name)");
+    sb.AppendLine("    {");
+    sb.AppendLine("        Mask = mask;");
+    sb.AppendLine("        Name = name;");
+    sb.AppendLine("    }");
     sb.AppendLine("}");
 
     sb.AppendLine();

--- a/Meziantou.Polyfill.Generator/Program.cs
+++ b/Meziantou.Polyfill.Generator/Program.cs
@@ -417,7 +417,7 @@ async Task GenerateMembers()
     sb.AppendLine("}");
 
     var entryIndexByTypeName = tableEntries
-        .Select((Entry, Index) => (Entry.Polyfill.TypeName, Index))
+        .Select((entry, index) => (entry.Polyfill.TypeName, Index: index))
         .ToDictionary(item => item.TypeName, item => item.Index, StringComparer.Ordinal);
 
     sb.AppendLine("public string DumpAsCSharpComment()");

--- a/Meziantou.Polyfill.SourceGenerator.Tests/SourceGeneratorTests.cs
+++ b/Meziantou.Polyfill.SourceGenerator.Tests/SourceGeneratorTests.cs
@@ -444,6 +444,76 @@ public sealed class SourceGeneratorTests
         Assert.DoesNotContain("PolyfillExtensions.g.cs", allFileNames);
     }
 
+    [Fact]
+    public async Task DebugFile_NotGenerated_ByDefault()
+    {
+        var assemblies = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "3.1.0", "ref/netcoreapp3.1/");
+
+        var result = GenerateFiles(
+            "",
+            assemblyLocations: assemblies,
+            includedPolyfills: "M:System.Linq.Enumerable.OrderDescending``1(System.Collections.Generic.IEnumerable{``0})");
+
+        Assert.DoesNotContain("Debug.g.cs", GetFileNames(result.GeneratorResult, includeAlwaysGeneratedFiles: true));
+    }
+
+    [Fact]
+    public async Task DebugFile_Generated_WhenEnabled()
+    {
+        var assemblies = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "3.1.0", "ref/netcoreapp3.1/");
+
+        var result = GenerateFiles(
+            "",
+            assemblyLocations: assemblies,
+            includedPolyfills: "M:System.Linq.Enumerable.OrderDescending``1(System.Collections.Generic.IEnumerable{``0})",
+            generateDebugFile: true);
+
+        var content = GetGeneratedFileContent(result.GeneratorResult, "Debug.g.cs");
+        Assert.Contains("// GenerateDebugFile: True", content, StringComparison.Ordinal);
+        Assert.Contains("// M:System.Linq.Enumerable.OrderDescending``1(System.Collections.Generic.IEnumerable{``0}): True", content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DebugFile_ReportsSkipReasons()
+    {
+        var netCore31Assemblies = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "3.1.0", "ref/netcoreapp3.1/");
+        var latestAssemblies = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", LatestDotnetPackageVersion, $"ref/{LatestDotnetTfm}/");
+        var net462Assemblies = await NuGetHelpers.GetNuGetReferences("Microsoft.NETFramework.ReferenceAssemblies.net462", "1.0.3", "");
+
+        var excludedResult = GenerateFiles(
+            "",
+            assemblyLocations: netCore31Assemblies,
+            includedPolyfills: "M:System.Linq.Enumerable.OrderDescending``1(System.Collections.Generic.IEnumerable{``0})",
+            excludedPolyfills: "M:System.Linq.Enumerable.OrderDescending``1(System.Collections.Generic.IEnumerable{``0})",
+            generateDebugFile: true);
+        var excludedContent = GetGeneratedFileContent(excludedResult.GeneratorResult, "Debug.g.cs");
+        Assert.Contains("// M:System.Linq.Enumerable.OrderDescending``1(System.Collections.Generic.IEnumerable{``0}): False (excluded by options)", excludedContent, StringComparison.Ordinal);
+
+        var alreadyAvailableResult = GenerateFiles(
+            "",
+            assemblyLocations: latestAssemblies,
+            includedPolyfills: "M:System.Linq.Enumerable.OrderDescending``1(System.Collections.Generic.IEnumerable{``0})",
+            generateDebugFile: true);
+        var alreadyAvailableContent = GetGeneratedFileContent(alreadyAvailableResult.GeneratorResult, "Debug.g.cs");
+        Assert.Contains("// M:System.Linq.Enumerable.OrderDescending``1(System.Collections.Generic.IEnumerable{``0}): False (already available in compilation)", alreadyAvailableContent, StringComparison.Ordinal);
+
+        var missingTypeResult = GenerateFiles(
+            "",
+            assemblyLocations: net462Assemblies,
+            includedPolyfills: "M:System.Random.NextBytes(System.Span{System.Byte})",
+            generateDebugFile: true);
+        var missingTypeContent = GetGeneratedFileContent(missingTypeResult.GeneratorResult, "Debug.g.cs");
+        Assert.Contains("// M:System.Random.NextBytes(System.Span{System.Byte}): False (missing required features: T:System.Span`1)", missingTypeContent, StringComparison.Ordinal);
+
+        var conditionalResult = GenerateFiles(
+            "",
+            assemblyLocations: netCore31Assemblies,
+            includedPolyfills: "T:System.ITupleInternal",
+            generateDebugFile: true);
+        var conditionalContent = GetGeneratedFileContent(conditionalResult.GeneratorResult, "Debug.g.cs");
+        Assert.Contains("// T:System.ITupleInternal: False (conditional dependencies not generated: T:System.ValueTuple", conditionalContent, StringComparison.Ordinal);
+    }
+
     private static string[] GetGeneratedFileLines(GeneratorDriverRunResult generatorResult, string fileName)
     {
         return GetGeneratedFileContent(generatorResult, fileName)
@@ -595,7 +665,7 @@ public sealed class SourceGeneratorTests
         }
     }
 
-    private static (GeneratorDriverRunResult GeneratorResult, Compilation OutputCompilation, byte[]? Assembly) GenerateFiles(string file, string assemblyName = "compilation", bool mustCompile = true, IEnumerable<string>? assemblyLocations = null, string? includedPolyfills = null, string? excludedPolyfills = null, LanguageVersion languageVersion = LanguageVersion.Preview, bool allowUnsafe = true)
+    private static (GeneratorDriverRunResult GeneratorResult, Compilation OutputCompilation, byte[]? Assembly) GenerateFiles(string file, string assemblyName = "compilation", bool mustCompile = true, IEnumerable<string>? assemblyLocations = null, string? includedPolyfills = null, string? excludedPolyfills = null, bool generateDebugFile = false, LanguageVersion languageVersion = LanguageVersion.Preview, bool allowUnsafe = true)
     {
         assemblyLocations ??= Array.Empty<string>();
         var references = assemblyLocations
@@ -618,6 +688,7 @@ public sealed class SourceGeneratorTests
             {
                 ["build_property.MeziantouPolyfill_IncludedPolyfills"] = includedPolyfills,
                 ["build_property.MeziantouPolyfill_ExcludedPolyfills"] = excludedPolyfills,
+                ["build_property.MeziantouPolyfill_GenerateDebugFile"] = generateDebugFile ? "true" : null,
             }));
 
         driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);

--- a/Meziantou.Polyfill/Members.cs
+++ b/Meziantou.Polyfill/Members.cs
@@ -8,9 +8,13 @@ namespace Meziantou.Polyfill;
 internal partial struct Members
 {
     private static bool IncludeMember(IncludeContext context, string memberDocumentationId)
+        => GetMemberSkipReason(context, memberDocumentationId) is null;
+
+    private static string? GetMemberSkipReason(IncludeContext context, string memberDocumentationId)
     {
-        if (context.Options is not null && !context.Options.Include(memberDocumentationId))
-            return false;
+        var optionSkipReason = context.Options?.GetSkipReason(memberDocumentationId);
+        if (optionSkipReason is not null)
+            return optionSkipReason;
 
         var compilation = context.Compilation;
         var currentAssembly = compilation.Assembly;
@@ -19,7 +23,7 @@ internal partial struct Members
         foreach (var symbol in symbols)
         {
             if (ReferenceEquals(symbol.ContainingAssembly, currentAssembly))
-                return false;
+                return "already available in compilation";
 
             // IsEmbeddedSymbol is a workaround for https://github.com/dotnet/roslyn/issues/79498
             if (compilation.IsSymbolAccessibleWithin(symbol, currentAssembly) && !context.IsEmbeddedSymbol(symbol))
@@ -33,15 +37,15 @@ internal partial struct Members
                     // The symbol is accessible from multiple assemblies, which would cause
                     // ambiguity (e.g. CS0433). Generate a local copy so the compiler prefers
                     // the current assembly's definition.
-                    return true;
+                    return null;
                 }
             }
         }
 
         if (accessibleFromAssembly is not null)
-            return false;
+            return "already available in compilation";
 
-        return true;
+        return null;
     }
 
     private void AddSource(SourceProductionContext context, string path, string content)

--- a/Meziantou.Polyfill/Meziantou.Polyfill.targets
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.targets
@@ -2,6 +2,7 @@
   <ItemGroup>
     <CompilerVisibleProperty Include="MeziantouPolyfill_IncludedPolyfills" />
     <CompilerVisibleProperty Include="MeziantouPolyfill_ExcludedPolyfills" />
+    <CompilerVisibleProperty Include="MeziantouPolyfill_GenerateDebugFile" />
   </ItemGroup>
   <PropertyGroup>
     <MeziantouPolyfill_AllowUnsafeBlocks Condition="'$(MeziantouPolyfill_AllowUnsafeBlocks)' == ''">true</MeziantouPolyfill_AllowUnsafeBlocks>

--- a/Meziantou.Polyfill/PolyfillGenerator.cs
+++ b/Meziantou.Polyfill/PolyfillGenerator.cs
@@ -24,7 +24,8 @@ public sealed partial class PolyfillGenerator : IIncrementalGenerator
         {
             return new PolyfillOptions(
                 included: GetValueOrDefault(options.GlobalOptions, "build_property.MeziantouPolyfill_IncludedPolyfills"),
-                excluded: GetValueOrDefault(options.GlobalOptions, "build_property.MeziantouPolyfill_ExcludedPolyfills"));
+                excluded: GetValueOrDefault(options.GlobalOptions, "build_property.MeziantouPolyfill_ExcludedPolyfills"),
+                generateDebugFile: IsTrue(GetValueOrDefault(options.GlobalOptions, "build_property.MeziantouPolyfill_GenerateDebugFile")));
         }).WithTrackingName("Options");
 
         var provider = context.CompilationProvider
@@ -35,7 +36,10 @@ public sealed partial class PolyfillGenerator : IIncrementalGenerator
 
         context.RegisterImplementationSourceOutput(provider, (context, members) =>
         {
-            context.AddSource("Debug.g.cs", SourceText.From(members.DumpAsCSharpComment(), Encoding.UTF8));
+            if (members.GenerateDebugFile)
+            {
+                context.AddSource("Debug.g.cs", SourceText.From(members.DumpAsCSharpComment(), Encoding.UTF8));
+            }
 
             // The EmbeddedAttribute definition is only needed when at least one polyfill is
             // generated; every polyfill source either decorates its types with the attribute
@@ -70,5 +74,10 @@ public sealed partial class PolyfillGenerator : IIncrementalGenerator
             return value;
 
         return null;
+    }
+
+    private static bool IsTrue(string? value)
+    {
+        return value is "1" || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Meziantou.Polyfill/PolyfillOptions.cs
+++ b/Meziantou.Polyfill/PolyfillOptions.cs
@@ -8,47 +8,40 @@ internal sealed class PolyfillOptions : IEquatable<PolyfillOptions>
     private readonly string[]? _included;
     private readonly string[]? _excluded;
 
-    public PolyfillOptions(string? included, string? excluded)
+    public PolyfillOptions(string? included, string? excluded, bool generateDebugFile = false)
     {
         _included = ParseValues(included);
         _excluded = ParseValues(excluded);
+        GenerateDebugFile = generateDebugFile;
     }
 
-    public bool Include(string memberDocumentationId)
+    public bool GenerateDebugFile { get; }
+
+    public bool Include(string memberDocumentationId) => GetSkipReason(memberDocumentationId) is null;
+
+    public string? GetSkipReason(string memberDocumentationId)
     {
         if (_excluded is not null)
         {
-            var found = false;
             foreach (var filter in _excluded)
             {
                 if (memberDocumentationId.StartsWith(filter, StringComparison.Ordinal))
-                {
-                    found = true;
-                    break;
-                }
+                    return "excluded by options";
             }
-
-            if (found)
-                return false;
         }
 
         if (_included is not null)
         {
-            var found = false;
             foreach (var filter in _included)
             {
                 if (memberDocumentationId.StartsWith(filter, StringComparison.Ordinal))
-                {
-                    found = true;
-                    break;
-                }
+                    return null;
             }
 
-            if (!found)
-                return false;
+            return "not included by options";
         }
 
-        return true;
+        return null;
     }
 
     private static string[]? ParseValues(string? value)
@@ -76,14 +69,15 @@ internal sealed class PolyfillOptions : IEquatable<PolyfillOptions>
         return [.. values];
     }
 
-    public override int GetHashCode() => 0;
+    public override int GetHashCode() => GenerateDebugFile ? 1 : 0;
     public override bool Equals(object obj) => Equals(obj as PolyfillOptions);
     public bool Equals(PolyfillOptions? other)
     {
         if (other == null)
             return false;
 
-        return SequenceEqual(_included, other._included)
+        return GenerateDebugFile == other.GenerateDebugFile
+            && SequenceEqual(_included, other._included)
             && SequenceEqual(_excluded, other._excluded);
 
         static bool SequenceEqual(string[]? value1, string[]? value2)
@@ -101,7 +95,8 @@ internal sealed class PolyfillOptions : IEquatable<PolyfillOptions>
     public string DumpAsCSharpComment()
     {
         return "// IncludedMembers: " + (_included == null ? "<null>" : string.Join(";", _included)) + "\n"
-             + "// ExcludedMembers: " + (_excluded == null ? "<null>" : string.Join(";", _excluded));
+             + "// ExcludedMembers: " + (_excluded == null ? "<null>" : string.Join(";", _excluded)) + "\n"
+             + "// GenerateDebugFile: " + GenerateDebugFile;
     }
 
     [StructLayout(LayoutKind.Auto)]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By default, all needed polyfills are generated. You can configure which polyfill
 <PropertyGroup>
   <!-- Opt-in: semicolon-separated or pipe-separated list of name prefixes to include (allowlist) -->
   <!-- When set, ONLY polyfills matching these prefixes will be generated -->
-  <!-- Tip: The name of the generated polyfills are available in the generated "Debug.g.cs" file -->
+  <!-- Tip: The names of the available polyfills and skip reasons are available when Debug.g.cs is enabled -->
   <MeziantouPolyfill_IncludedPolyfills>T:Type1|T:Type2|M:Member1</MeziantouPolyfill_IncludedPolyfills>
 
   <!-- Opt-out: semicolon-separated or pipe-separated list of name prefixes to exclude (blocklist) -->
@@ -36,6 +36,9 @@ By default, all needed polyfills are generated. You can configure which polyfill
   <!-- Optional: Output the generated files to the obj\GeneratedFiles folder  -->
   <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
   <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
+
+  <!-- Optional: Generate Debug.g.cs with polyfill generation decisions and skip reasons -->
+  <MeziantouPolyfill_GenerateDebugFile>true</MeziantouPolyfill_GenerateDebugFile>
 </PropertyGroup>
 ````
 
@@ -55,6 +58,8 @@ The filtering logic works as follows:
 2. **MeziantouPolyfill_ExcludedPolyfills** (opt-out/blocklist): Excludes polyfills whose XML documentation ID starts with any of the specified prefixes
 3. **MeziantouPolyfill_IncludedPolyfills** (opt-in/allowlist): When set, ONLY includes polyfills whose XML documentation ID starts with any of the specified prefixes
 4. **Both properties set**: Exclusions are applied first, then inclusions. A polyfill must match an inclusion filter AND not match any exclusion filter to be generated
+
+Set **MeziantouPolyfill_GenerateDebugFile** to `true` to emit `Debug.g.cs`. This diagnostic file lists required type availability, each polyfill generation decision, and skip reasons such as already-available members, excluded filters, missing required types, or unmet conditional dependencies.
 
 ## Supported polyfills
 


### PR DESCRIPTION
Debug.g.cs was useful for seeing which polyfills were generated, but it did not explain why a polyfill was skipped. To avoid adding default compilation-time or memory overhead, this makes the debug file opt-in through `MeziantouPolyfill_GenerateDebugFile`.

When enabled, the generator now records and emits skip reasons for filtered polyfills, already-available symbols, missing required features or types, unmet conditional dependencies, and declared-member blockers. The debug-only metadata is kept on the diagnostic path, while normal generation continues without emitting Debug.g.cs. The README documents the new property.

Validation:
- `dotnet run --project ./Meziantou.Polyfill.Generator/Meziantou.Polyfill.Generator.csproj`
- `dotnet build` (0 warnings)
- Source-generator tests plus `net8.0`, `net9.0`, `net10.0`, and `net11.0` test targets

Note: full `dotnet test` reaches the .NET Framework targets but is blocked in this environment because `mono` is not installed for `net472`/`net48`/`net481`.