### PR TITLE
Add Stream and TextReader async I/O polyfills

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.IO.Stream.CopyToAsync(System.IO.Stream,System.Threading.CancellationToken).cs
+++ b/Meziantou.Polyfill.Editor/M;System.IO.Stream.CopyToAsync(System.IO.Stream,System.Threading.CancellationToken).cs
@@ -1,0 +1,11 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+static partial class PolyfillExtensions
+{
+    public static Task CopyToAsync(this Stream target, Stream destination, CancellationToken cancellationToken)
+    {
+        return target.CopyToAsync(destination, 81920, cancellationToken);
+    }
+}

--- a/Meziantou.Polyfill.Editor/M;System.IO.TextReader.ReadBlockAsync(System.Memory{System.Char},System.Threading.CancellationToken).cs
+++ b/Meziantou.Polyfill.Editor/M;System.IO.TextReader.ReadBlockAsync(System.Memory{System.Char},System.Threading.CancellationToken).cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+static partial class PolyfillExtensions
+{
+    public static ValueTask<int> ReadBlockAsync(this TextReader target, Memory<char> buffer, CancellationToken cancellationToken = default)
+    {
+        if (MemoryMarshal.TryGetArray((ReadOnlyMemory<char>)buffer, out var segment))
+        {
+            return ReadBlockAsyncCore(target, segment.Array!, segment.Offset, segment.Count, cancellationToken);
+        }
+
+        return ReadBlockAsyncFallback(target, buffer, cancellationToken);
+    }
+
+    private static async ValueTask<int> ReadBlockAsyncFallback(TextReader target, Memory<char> buffer, CancellationToken cancellationToken)
+    {
+        var tempArray = new char[buffer.Length];
+        var charsRead = await ReadBlockAsyncCore(target, tempArray, 0, tempArray.Length, cancellationToken).ConfigureAwait(false);
+        tempArray.AsMemory(0, charsRead).CopyTo(buffer);
+        return charsRead;
+    }
+
+    private static async ValueTask<int> ReadBlockAsyncCore(TextReader target, char[] buffer, int index, int count, CancellationToken cancellationToken)
+    {
+        var totalCharsRead = 0;
+        int charsRead;
+        do
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            charsRead = await target.ReadAsync(buffer, index + totalCharsRead, count - totalCharsRead).ConfigureAwait(false);
+            totalCharsRead += charsRead;
+        } while (charsRead > 0 && totalCharsRead < count);
+
+        return totalCharsRead;
+    }
+}

--- a/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
+++ b/Meziantou.Polyfill.Generator/polyfill-supported-versions.json
@@ -2088,6 +2088,15 @@
       "net10.0",
       "net11.0"
     ],
+    "M:System.IO.Stream.CopyToAsync(System.IO.Stream,System.Threading.CancellationToken)": [
+      "netstandard2.1",
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0",
+      "net11.0"
+    ],
     "M:System.IO.Stream.DisposeAsync()": [
       "netstandard2.1",
       "net6.0",
@@ -2182,6 +2191,15 @@
       "net11.0"
     ],
     "M:System.IO.TextReader.ReadAsync(System.Memory{System.Char},System.Threading.CancellationToken)": [
+      "netstandard2.1",
+      "net6.0",
+      "net7.0",
+      "net8.0",
+      "net9.0",
+      "net10.0",
+      "net11.0"
+    ],
+    "M:System.IO.TextReader.ReadBlockAsync(System.Memory{System.Char},System.Threading.CancellationToken)": [
       "netstandard2.1",
       "net6.0",
       "net7.0",

--- a/Meziantou.Polyfill.Tests/SystemIOTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemIOTests.cs
@@ -219,6 +219,70 @@ public class SystemIOTests
     }
 
     [Fact]
+    public async Task Stream_CopyToAsync_CancellationToken()
+    {
+        using var source = new MemoryStream([1, 2, 3, 4, 5]);
+        using var destination = new MemoryStream();
+
+        await source.CopyToAsync(destination, CancellationToken.None);
+
+        Assert.Equal([1, 2, 3, 4, 5], destination.ToArray());
+    }
+
+    [Fact]
+    public async Task Stream_CopyToAsync_CancellationToken_Canceled()
+    {
+        using var source = new MemoryStream([1, 2, 3, 4, 5]);
+        using var destination = new MemoryStream();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => source.CopyToAsync(destination, cancellationTokenSource.Token));
+
+        Assert.Equal(cancellationTokenSource.Token, exception.CancellationToken);
+        Assert.Empty(destination.ToArray());
+    }
+
+    [Fact]
+    public async Task TextReader_ReadBlockAsync_Memory()
+    {
+        using var reader = new ChunkedTextReader("abcd", maxCharsPerRead: 2);
+        var buffer = new[] { 'x', 'x', 'x', 'x', 'x' };
+
+        var charsRead = await reader.ReadBlockAsync(buffer.AsMemory(1, 4), CancellationToken.None);
+
+        Assert.Equal(4, charsRead);
+        Assert.Equal(['x', 'a', 'b', 'c', 'd'], buffer);
+        Assert.True(reader.ReadCount >= 2);
+    }
+
+    [Fact]
+    public async Task TextReader_ReadBlockAsync_Memory_NonArrayBacked()
+    {
+        using var reader = new StringReader("abcde");
+        using var manager = new NonArrayCharMemoryManager(3);
+
+        var charsRead = await reader.ReadBlockAsync(manager.Memory, CancellationToken.None);
+
+        Assert.Equal(3, charsRead);
+        Assert.Equal("abc", new string(manager.Data.ToArray()));
+    }
+
+    [Fact]
+    public async Task TextReader_ReadBlockAsync_Memory_Canceled()
+    {
+        using var reader = new StringReader("abcde");
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+        var buffer = new char[3];
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await reader.ReadBlockAsync(buffer.AsMemory(), cancellationTokenSource.Token));
+
+        Assert.Equal(cancellationTokenSource.Token, exception.CancellationToken);
+        Assert.Equal(['\0', '\0', '\0'], buffer);
+    }
+
+    [Fact]
     public async Task Stream_WriteAsync_ReadOnlyMemory()
     {
         using var ms = new MemoryStream();
@@ -300,6 +364,47 @@ public class SystemIOTests
         public override void Unpin() { }
 
         protected override void Dispose(bool disposing) { }
+    }
+
+    private sealed class NonArrayCharMemoryManager : MemoryManager<char>
+    {
+        private readonly char[] _array;
+
+        public NonArrayCharMemoryManager(int size) => _array = new char[size];
+
+        public ReadOnlySpan<char> Data => _array;
+
+        public override Span<char> GetSpan() => _array;
+
+        public override MemoryHandle Pin(int elementIndex = 0) => throw new NotSupportedException();
+
+        public override void Unpin() { }
+
+        protected override void Dispose(bool disposing) { }
+    }
+
+    private sealed class ChunkedTextReader : TextReader
+    {
+        private readonly string _text;
+        private readonly int _maxCharsPerRead;
+        private int _position;
+
+        public ChunkedTextReader(string text, int maxCharsPerRead)
+        {
+            _text = text;
+            _maxCharsPerRead = maxCharsPerRead;
+        }
+
+        public int ReadCount { get; private set; }
+
+        public override int Read(char[] buffer, int index, int count)
+        {
+            ReadCount++;
+            var charsToRead = Math.Min(Math.Min(count, _maxCharsPerRead), _text.Length - _position);
+            _text.CopyTo(_position, buffer, index, charsToRead);
+            _position += charsToRead;
+            return charsToRead;
+        }
     }
 #endif
 

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.159</Version>
+    <Version>1.0.160</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Dependency annotations use XML documentation IDs and indicate symbols that must 
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7>`
 - `System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct`
 
-### Methods (1055)
+### Methods (1057)
 
 - `System.ArgumentException.ThrowIfNullOrEmpty(System.String? argument, [System.String? paramName = null])`
 - `System.ArgumentException.ThrowIfNullOrWhiteSpace(System.String? argument, [System.String? paramName = null])`
@@ -464,6 +464,7 @@ Dependency annotations use XML documentation IDs and indicate symbols that must 
 - `System.IO.Path.Join(params System.String?[] paths)`
 - `System.IO.Path.TrimEndingDirectorySeparator(System.ReadOnlySpan<System.Char> path)` _(requires ``T:System.ReadOnlySpan`1``)_
 - `System.IO.Path.TrimEndingDirectorySeparator(System.String path)`
+- `System.IO.Stream.CopyToAsync(System.IO.Stream destination, System.Threading.CancellationToken cancellationToken)`
 - `System.IO.Stream.DisposeAsync()` _(requires `T:System.Threading.Tasks.ValueTask`)_
 - `System.IO.Stream.Read(System.Span<System.Byte> buffer)` _(requires ``T:System.Span`1``)_
 - `System.IO.Stream.ReadAsync(System.Memory<System.Byte> buffer, [System.Threading.CancellationToken cancellationToken = default])` _(requires ``T:System.Memory`1``, ``T:System.Threading.Tasks.ValueTask`1``)_
@@ -476,6 +477,7 @@ Dependency annotations use XML documentation IDs and indicate symbols that must 
 - `System.IO.StreamReader.ReadLineAsync()`
 - `System.IO.StreamReader.ReadLineAsync(System.Threading.CancellationToken cancellationToken)` _(requires ``T:System.Threading.Tasks.ValueTask`1``)_
 - `System.IO.TextReader.ReadAsync(System.Memory<System.Char> buffer, [System.Threading.CancellationToken cancellationToken = default])` _(requires ``T:System.Memory`1``, ``T:System.ReadOnlyMemory`1``, ``T:System.Threading.Tasks.ValueTask`1``)_
+- `System.IO.TextReader.ReadBlockAsync(System.Memory<System.Char> buffer, [System.Threading.CancellationToken cancellationToken = default])` _(requires ``T:System.Memory`1``, ``T:System.ReadOnlyMemory`1``, ``T:System.Threading.Tasks.ValueTask`1``)_
 - `System.IO.TextReader.ReadLineAsync(System.Threading.CancellationToken cancellationToken)`
 - `System.IO.TextReader.ReadToEndAsync(System.Threading.CancellationToken cancellationToken)`
 - `System.IO.TextWriter.CreateBroadcasting(params System.IO.TextWriter[] writers)` _(requires `T:System.IAsyncDisposable`)_


### PR DESCRIPTION
## Summary

- Add `Stream.CopyToAsync` with cancellation-token support.
- Add `TextReader.ReadBlockAsync` for `Memory<char>` buffers.
- Update supported-version metadata, generated documentation, and package version.
- Add coverage for normal, non-array-backed, and canceled operations.

## Testing

- Added unit tests covering copying, buffered reads, cancellation, and partial reads.

Fix https://github.com/meziantou/Meziantou.Polyfill/issues/292