### PR TITLE
chore(deps): update Meziantou.NET.SDK to 1.0.145

### DIFF
--- a/Meziantou.Polyfill.SourceGenerator.Tests/Meziantou.Polyfill.SourceGenerator.Tests.csproj
+++ b/Meziantou.Polyfill.SourceGenerator.Tests/Meziantou.Polyfill.SourceGenerator.Tests.csproj
@@ -5,12 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Xunit.v3.ParallelTestFramework" Version="1.0.6" />
-	  <PackageReference Include="xunit.v3" Version="3.2.2" />
-	  <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="5.6.0" />
   </ItemGroup>
 

--- a/Meziantou.Polyfill.Tests/Meziantou.Polyfill.Tests.csproj
+++ b/Meziantou.Polyfill.Tests/Meziantou.Polyfill.Tests.csproj
@@ -14,12 +14,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
     <PackageReference Include="System.ValueTuple" Version="4.6.2" />
-    <PackageReference Include="Meziantou.Xunit.v3.ParallelTestFramework" Version="1.0.6" />
-	  <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <ProjectReference Include="..\Meziantou.Polyfill\Meziantou.Polyfill.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0" />
 
     <Reference Include="System.Net.Http" Condition="$(TargetFramework) == 'net472' OR $(TargetFramework) == 'net48' OR $(TargetFramework) == 'net481'" />

--- a/global.json
+++ b/global.json
@@ -2,8 +2,11 @@
   "sdk": {
     "version": "11.0.100-preview.7.26381.103"
   },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  },
   "msbuild-sdks": {
-    "Meziantou.NET.Sdk": "1.0.137",
-    "Meziantou.NET.Sdk.Test": "1.0.137"
+    "Meziantou.NET.Sdk": "1.0.145",
+    "Meziantou.NET.Sdk.Test": "1.0.145"
   }
 }


### PR DESCRIPTION
Updates `Meziantou.NET.Sdk` and `Meziantou.NET.Sdk.Test` from 1.0.137 to 1.0.145, and drops the test-project boilerplate the SDK now provides itself.

## What changed

**`global.json`**
- Both msbuild-sdks bumped to 1.0.145.
- Added the MTP opt-in so `dotnet test` runs in Microsoft Testing Platform mode:
  ```json
  "test": { "runner": "Microsoft.Testing.Platform" }
  ```

**`Meziantou.Polyfill.Tests` and `Meziantou.Polyfill.SourceGenerator.Tests`**

Removed three package references from each project:
- `xunit.v3` / `xunit.runner.visualstudio` — the SDK adds `xunit.v3.mtp-v2` 4.0.0 (plus the MTP extensions: TRX report, crash/hang dump, code coverage, GitHub Actions report) when the project references no test framework.
- `Meziantou.Xunit.v3.ParallelTestFramework` — the SDK now generates `[assembly: Xunit.v3.Parallelization(Mode = Xunit.Sdk.ParallelMode.All)]` when xUnit.net v3 4.0+ is resolved, which gives the same full parallelization.

There was no `dotnet.config` file and no explicit `UseMicrosoftTestingPlatform` property in the repo, so nothing to remove on those two points.

## Verification

Ran the generator first (`Members.g.cs` unchanged), then:

- `dotnet build` — succeeded, **0 warnings**, 0 errors.
- `dotnet test Meziantou.Polyfill.SourceGenerator.Tests` — 85/85 passed.
- `Meziantou.Polyfill.Tests` per TFM: net11.0 843, net10.0 843, net9.0 843, net8.0 837 — all passed.

## Note for the reviewer

The `net472` / `net48` / `net481` TFMs of `Meziantou.Polyfill.Tests` could not be executed locally (macOS) — `dotnet test` reports *"Running the ComputeRunArguments target to discover run commands failed"*, which also makes the solution-wide `dotnet test` fail on that host. This is not a regression from this change: on the pre-change tree those same TFMs already aborted with `Permission denied` launching the `.exe`. Both CI test jobs run on `windows-latest`, so those TFMs are covered there — worth confirming CI is green before merging.