### PR TITLE
Fully qualify Timer in the TimeProvider polyfill (fixes #300)

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.IO.Stream.DisposeAsync().cs
+++ b/Meziantou.Polyfill.Editor/M;System.IO.Stream.DisposeAsync().cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
 
 static partial class PolyfillExtensions
@@ -7,7 +6,7 @@ static partial class PolyfillExtensions
     public static async ValueTask DisposeAsync(this Stream target)
     {
 #if MEZIANTOU_POLYFILL_SUPPORTS_ASYNC_DISPOSABLE
-        if (target is IAsyncDisposable asyncDisposable)
+        if (target is global::System.IAsyncDisposable asyncDisposable)
         {
             await asyncDisposable.DisposeAsync().ConfigureAwait(false);
         }

--- a/Meziantou.Polyfill.Editor/T;System.TimeProvider.cs
+++ b/Meziantou.Polyfill.Editor/T;System.TimeProvider.cs
@@ -62,12 +62,12 @@ namespace System
 
         private sealed class SystemTimeProviderTimer : ITimer
         {
-            private readonly Timer _timer;
+            private readonly global::System.Threading.Timer _timer;
 
             public SystemTimeProviderTimer(TimeSpan dueTime, TimeSpan period, TimerCallback callback, object? state)
             {
                 var timerState = new TimerState(callback, state);
-                timerState.Timer = _timer = new Timer(static s =>
+                timerState.Timer = _timer = new global::System.Threading.Timer(static s =>
                 {
                     var ts = (TimerState)s!;
                     ts.Callback(ts.State);
@@ -78,7 +78,7 @@ namespace System
             {
                 public TimerCallback Callback { get; } = callback;
                 public object? State { get; } = state;
-                public Timer? Timer { get; set; }
+                public global::System.Threading.Timer? Timer { get; set; }
             }
 
             public bool Change(TimeSpan dueTime, TimeSpan period)

--- a/Meziantou.Polyfill.SourceGenerator.Tests/SourceGeneratorTests.cs
+++ b/Meziantou.Polyfill.SourceGenerator.Tests/SourceGeneratorTests.cs
@@ -229,6 +229,30 @@ public sealed class SourceGeneratorTests
     }
 
     [Fact]
+    public async Task GeneratedCodeCompile_WithWindowsFormsGlobalUsings()
+    {
+        // WinForms projects with ImplicitUsings bring both System.Threading and System.Windows.Forms in scope,
+        // which makes unqualified type names such as Timer ambiguous (CS0104) in the generated code.
+        var assemblies = new List<string>();
+        assemblies.AddRange(await NuGetHelpers.GetNuGetReferences("Microsoft.NETFramework.ReferenceAssemblies.net481", "1.0.3", ""));
+        assemblies.AddRange(await NuGetHelpers.GetNuGetReferences("System.Threading.Tasks.Extensions", "4.5.4", "lib/net461/"));
+        assemblies.AddRange(await NuGetHelpers.GetNuGetReferences("Microsoft.Bcl.AsyncInterfaces", "8.0.0", "lib/net462/"));
+
+        GenerateFiles(
+            """
+            global using System.Drawing;
+            global using System.Windows.Forms;
+
+            static class WinFormsUsage
+            {
+                public static object Form = typeof(Form);
+                public static object Point = typeof(Point);
+            }
+            """,
+            assemblyLocations: assemblies);
+    }
+
+    [Fact]
     public async Task GenericMathPolyfills_UseTypePresenceDefines()
     {
         var netCore31Assemblies = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "3.1.0", "ref/netcoreapp3.1/");

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.160</Version>
+    <Version>1.0.161</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 


### PR DESCRIPTION
Fixes #300.

## Problem

In a WinForms project with `ImplicitUsings=enable`, the generated `T_System.TimeProvider.g.cs` fails to compile:

```
CS0104: 'Timer' is an ambiguous reference between 'System.Windows.Forms.Timer' and 'System.Threading.Timer'
```

The polyfill imports `System.Threading` and refers to `Timer` unqualified. File-level `using` directives do **not** shadow `global using` directives, so the project's `global using System.Windows.Forms;` makes the name ambiguous regardless of what the generated file imports. Generated code should not depend on the consumer's using directives.

## Changes

- **`Meziantou.Polyfill.Editor/T;System.TimeProvider.cs`** — the three `Timer` references now use `global::System.Threading.Timer`. The `global::` prefix is necessary: the polyfill declares a `TimeProvider.System` property, so a bare `System.Threading.Timer` would bind `System` to that property instead of the namespace.
- **`Meziantou.Polyfill.SourceGenerator.Tests/SourceGeneratorTests.cs`** — new `GeneratedCodeCompile_WithWindowsFormsGlobalUsings` test. It generates every polyfill for net481 (plus `System.Threading.Tasks.Extensions` and `Microsoft.Bcl.AsyncInterfaces`, which are what make `TimeProvider`/`ITimer` eligible for generation) with `System.Drawing` and `System.Windows.Forms` as global usings. Both namespaces are referenced by a small `WinFormsUsage` class so they are not reported as unnecessary usings.
- **`Meziantou.Polyfill.Editor/M;System.IO.Stream.DisposeAsync().cs`** — the new test surfaced an unnecessary `using System;` here. It is only consumed by the `#if MEZIANTOU_POLYFILL_SUPPORTS_ASYNC_DISPOSABLE` branch, and that symbol is never defined by the generator, so the using is unnecessary in every configuration. No existing test config generated this polyfill (it needs `ValueTask`). The using is removed and `IAsyncDisposable` qualified instead.
- Version bumped 1.0.160 → 1.0.161.

## Notes for the reviewer

- Since the test compiles the entire generated surface with `System.Windows.Forms` and `System.Drawing` in scope, `Timer` was the only ambiguity present.
- The dead `MEZIANTOU_POLYFILL_SUPPORTS_ASYNC_DISPOSABLE` define means `Stream.DisposeAsync` never routes through `IAsyncDisposable` even when it is available. That is a separate latent issue and the behaviour is untouched here.

## Verification

Ran on macOS after `dotnet run --project ./Meziantou.Polyfill.Generator`:

- `dotnet build` — 0 warnings, 0 errors.
- `Meziantou.Polyfill.SourceGenerator.Tests` — 86/86 passed. Reverting only the `TimeProvider` change makes the new test fail with the three CS0104 errors from the issue.
- `Meziantou.Polyfill.Tests` — 843 passed on net11.0/net10.0/net9.0, 837 on net8.0. The net472/net48/net481 targets build but cannot execute on macOS, so they were only covered by the build; they need Windows CI.