### PR TITLE
Fix String.Replace(string, string, StringComparison) for culture-sensitive comparisons

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.String.Replace(System.String,System.String,System.StringComparison).cs
+++ b/Meziantou.Polyfill.Editor/M;System.String.Replace(System.String,System.String,System.StringComparison).cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Text;
 
 static partial class PolyfillExtensions
@@ -11,17 +12,72 @@ static partial class PolyfillExtensions
         if (oldValue == "")
             throw new ArgumentException("The value cannot be an empty string.", nameof(oldValue));
 
+        // Ordinal comparisons always match exactly oldValue.Length characters. Culture-sensitive comparisons
+        // can match a region of the target whose length differs from oldValue.Length, so the length of the
+        // match must be computed for each occurrence.
+        CompareInfo? compareInfo = null;
+        var compareOptions = CompareOptions.None;
+        switch (comparisonType)
+        {
+            case StringComparison.CurrentCulture:
+                compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+                break;
+
+            case StringComparison.CurrentCultureIgnoreCase:
+                compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+                compareOptions = CompareOptions.IgnoreCase;
+                break;
+
+            case StringComparison.InvariantCulture:
+                compareInfo = CultureInfo.InvariantCulture.CompareInfo;
+                break;
+
+            case StringComparison.InvariantCultureIgnoreCase:
+                compareInfo = CultureInfo.InvariantCulture.CompareInfo;
+                compareOptions = CompareOptions.IgnoreCase;
+                break;
+        }
+
         var sb = new StringBuilder();
 
         var previousIndex = 0;
         while (target.IndexOf(oldValue, previousIndex, comparisonType) is var index and not -1)
         {
+            int matchLength;
+            if (compareInfo == null)
+            {
+                matchLength = oldValue.Length;
+            }
+            else
+            {
+                matchLength = GetMatchLength(compareInfo, target, index, oldValue, compareOptions);
+
+                // oldValue has no collation weight (or no match length could be determined):
+                // behave as if there is nothing left to replace
+                if (matchLength <= 0)
+                    break;
+            }
+
             sb.Append(target, previousIndex, index - previousIndex);
             sb.Append(newValue);
-            previousIndex = index + oldValue.Length;
+            previousIndex = index + matchLength;
         }
 
         sb.Append(target, previousIndex, target.Length - previousIndex);
         return sb.ToString();
+
+        // Equivalent of CompareInfo.IndexOf(..., out int matchLength) which is not available on all
+        // the supported frameworks: find the shortest region of target starting at index that is
+        // equal to oldValue. Returns -1 when no such region exists.
+        static int GetMatchLength(CompareInfo compareInfo, string target, int index, string oldValue, CompareOptions options)
+        {
+            for (var length = 0; index + length <= target.Length; length++)
+            {
+                if (compareInfo.Compare(target, index, length, oldValue, 0, oldValue.Length, options) == 0)
+                    return length;
+            }
+
+            return -1;
+        }
     }
 }

--- a/Meziantou.Polyfill.Tests/SystemTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
@@ -104,6 +104,41 @@ public class SystemTests
         Assert.Throws<ArgumentException>(() => "".Replace("", "dummy", StringComparison.OrdinalIgnoreCase));
         Assert.Throws<ArgumentNullException>(() => "".Replace(null!, "dummy", StringComparison.OrdinalIgnoreCase));
     }
+
+#pragma warning disable RS0030 // Culture-sensitive comparisons are the subject of these tests
+    [Theory]
+    [InlineData(StringComparison.InvariantCulture)]
+    [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+    public void String_Replace_CultureSensitive_MatchLongerThanOldValue(StringComparison comparisonType)
+    {
+        // U+00AD SOFT HYPHEN is ignorable by the collation, so the matched region is longer than oldValue
+        Assert.Equal("Z", "ab\u00ADc".Replace("abc", "Z", comparisonType));
+        Assert.Equal("Z", "a\u00ADb\u00ADc".Replace("abc", "Z", comparisonType));
+        Assert.Equal("xZy", "xa\u00ADbcy".Replace("abc", "Z", comparisonType));
+        Assert.Equal("Z Z", "a\u00ADbc a\u00ADbc".Replace("abc", "Z", comparisonType));
+        Assert.Equal("\u00ADZ\u00AD", "\u00ADabc\u00AD".Replace("abc", "Z", comparisonType));
+    }
+
+    [Theory]
+    [InlineData(StringComparison.InvariantCulture)]
+    [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+    public void String_Replace_CultureSensitive_MatchShorterThanOldValue(StringComparison comparisonType)
+    {
+        Assert.Equal("Z", "ac".Replace("a\u00ADc", "Z", comparisonType));
+        Assert.Equal("Z Z", "ac ac".Replace("a\u00ADc", "Z", comparisonType));
+    }
+
+    [Theory]
+    [InlineData(StringComparison.InvariantCulture)]
+    [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+    public void String_Replace_CultureSensitive_IgnorableOldValue(StringComparison comparisonType)
+    {
+        // oldValue has no collation weight, so nothing is replaced
+        Assert.Equal("abc", "abc".Replace("\u00AD", "Z", comparisonType));
+        Assert.Equal("ab\u00ADc", "ab\u00ADc".Replace("\u00AD", "Z", comparisonType));
+        Assert.Equal("\u00AD\u00AD", "\u00AD\u00AD".Replace("\u00AD", "Z", comparisonType));
+    }
+#pragma warning restore RS0030
 
     [Fact]
     public void String_Split()

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.161</Version>
+    <Version>1.0.162</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 


### PR DESCRIPTION
Fixes #303

## What was wrong

The polyfill advanced its scan position by `oldValue.Length`, but under a culture-sensitive comparison the matched region in the target can have a different length than `oldValue`. The real BCL implementation advances by the actual match length obtained from `CompareInfo.IndexOf(..., out int matchLength)`.

Depending on which way the lengths differ, the polyfill either threw `ArgumentOutOfRangeException`, silently truncated the result, or silently left stray characters in the output. Since `matchLength == oldValue.Length` always holds for ordinal comparisons, the bug was invisible in ordinal usage.

| Expression (`InvariantCulture`) | Expected | Before |
|---|---|---|
| `"Maß".Replace("ss", "X", …)` | `"MaX"` | throws `ArgumentOutOfRangeException` |
| `"Maße".Replace("ss", "X", …)` | `"MaXe"` | `"MaX"` — trailing `e` lost |
| `"ab­c".Replace("abc", "Z", …)` | `"Z"` | `"Zc"` — stray `c` left behind |

## What changed

- **Ordinal / OrdinalIgnoreCase**: unchanged fast path. `matchLength == oldValue.Length` always holds, so there is no extra cost or allocation for the overwhelmingly common case.
- **Culture-sensitive comparisons**: the `CompareInfo` / `CompareOptions` pair is resolved from the `StringComparison`, and the real match length is computed for each occurrence as the shortest `length` for which `compareInfo.Compare(target, index, length, oldValue, 0, oldValue.Length, options) == 0`. This stands in for `CompareInfo.IndexOf(..., out int matchLength)`, which is .NET 5+ only and therefore unavailable on the frameworks this polyfill targets.
- **`oldValue` with no collation weight** (e.g. `"­"` alone, which yields a match length of 0): the polyfill now stops replacing and appends the remainder, which is what the BCL's `ReplaceCore` does — it breaks out of the loop on `matchLength == 0`. This matches the runtime rather than applying a `Math.Max(matchLength, 1)` floor, and it removes the infinite-loop risk.

Version bumped to 1.0.162.

## Tests

Three new theories in `SystemTests.cs` covering a match longer than `oldValue`, a match shorter than `oldValue`, and the ignorable-`oldValue` degenerate case.

They use only `U+00AD SOFT HYPHEN` cases, which are collation-ignorable under both ICU and NLS. The `ß` / `ss` cases from the issue are NLS contractions and would fail on the Linux leg of CI, so they are deliberately not asserted. The tests need `#pragma warning disable RS0030` because the SDK bans culture-sensitive `StringComparison` values in this project — exercising them is the point of these tests.

## Verification

- `dotnet run --project Meziantou.Polyfill.Generator` (no change to `Members.g.cs`), then `dotnet build` — 0 warnings, 0 errors.
- `dotnet test` passes on net8.0, net9.0, net10.0 and net11.0, plus `Meziantou.Polyfill.SourceGenerator.Tests`.
- The net472/net48/net481 targets — the ones that actually consume the polyfill — cannot run on macOS, so instead the **generated** `.g.cs` from `obj/GeneratedFiles/net472` was compiled into a scratch net10.0 harness and diffed against the real `string.Replace` over 168 (target, oldValue, comparison) combinations, including all three cases from the issue. Every result matched.
- That check is ICU-only. The NLS behaviour (cases 1 and 2 of the issue) is unverified locally since NLS is Windows-only, but the algorithm now mirrors the BCL's regardless of the collation backend. The Windows CI leg covers the .NET Framework targets.