### PR TITLE
Fix String.Replace(string, string, StringComparison) match length under NLS.

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.String.Replace(System.String,System.String,System.StringComparison).cs
+++ b/Meziantou.Polyfill.Editor/M;System.String.Replace(System.String,System.String,System.StringComparison).cs
@@ -38,6 +38,19 @@ static partial class PolyfillExtensions
                 break;
         }
 
+        // NLS folds the target characters that pair with oldValue's own weightless tail into the match, so
+        // the shortest equal region falls one character short for each of them. The count only depends on
+        // oldValue, so it is computed once instead of once per occurrence.
+        var ignorableTail = 0;
+        if (compareInfo != null && ExtendsMatchOverIgnorableTail(compareInfo, compareOptions))
+        {
+            while (ignorableTail < oldValue.Length &&
+                   HasNoCollationWeight(compareInfo, oldValue, oldValue.Length - ignorableTail - 1, ignorableTail + 1, compareOptions))
+            {
+                ignorableTail++;
+            }
+        }
+
         var sb = new StringBuilder();
 
         var previousIndex = 0;
@@ -50,7 +63,7 @@ static partial class PolyfillExtensions
             }
             else
             {
-                matchLength = GetMatchLength(compareInfo, target, index, oldValue, compareOptions);
+                matchLength = GetMatchLength(compareInfo, target, index, oldValue, compareOptions, ignorableTail);
 
                 // oldValue has no collation weight (or no match length could be determined):
                 // behave as if there is nothing left to replace
@@ -66,18 +79,47 @@ static partial class PolyfillExtensions
         sb.Append(target, previousIndex, target.Length - previousIndex);
         return sb.ToString();
 
-        // Equivalent of CompareInfo.IndexOf(..., out int matchLength) which is not available on all
-        // the supported frameworks: find the shortest region of target starting at index that is
-        // equal to oldValue. Returns -1 when no such region exists.
-        static int GetMatchLength(CompareInfo compareInfo, string target, int index, string oldValue, CompareOptions options)
+        // Equivalent of CompareInfo.IndexOf(..., out int matchLength) which is not available on all the
+        // supported frameworks: find the shortest region of target starting at index that is equal to
+        // oldValue, then extend it over the weightless characters NLS folds into the match.
+        // Returns -1 when no such region exists.
+        static int GetMatchLength(CompareInfo compareInfo, string target, int index, string oldValue, CompareOptions options, int ignorableTail)
         {
-            for (var length = 0; index + length <= target.Length; length++)
+            var length = -1;
+            for (var candidate = 0; index + candidate <= target.Length; candidate++)
             {
-                if (compareInfo.Compare(target, index, length, oldValue, 0, oldValue.Length, options) == 0)
-                    return length;
+                if (compareInfo.Compare(target, index, candidate, oldValue, 0, oldValue.Length, options) == 0)
+                {
+                    length = candidate;
+                    break;
+                }
             }
 
-            return -1;
+            // No match, or oldValue is weightless in its entirety. Extending a zero-length match would turn
+            // "there is nothing to replace" into a replacement, so leave it for the caller to stop on.
+            if (length <= 0)
+                return length;
+
+            var remaining = ignorableTail;
+            while (remaining > 0 &&
+                   index + length < target.Length &&
+                   HasNoCollationWeight(compareInfo, target, index + length, 1, options))
+            {
+                length++;
+                remaining--;
+            }
+
+            return length;
         }
+
+        static bool HasNoCollationWeight(CompareInfo compareInfo, string value, int index, int length, CompareOptions options)
+            => compareInfo.Compare(value, index, length, "", 0, 0, options) == 0;
+
+        // Only NLS extends a match over the weightless characters that pair with oldValue's tail; applying
+        // the rule under ICU makes the result worse. NLS also compares U+00DF (LATIN SMALL LETTER SHARP S)
+        // equal to "ss" at the default strength while ICU does not, which tells the two implementations
+        // apart without depending on globalization internals.
+        static bool ExtendsMatchOverIgnorableTail(CompareInfo compareInfo, CompareOptions options)
+            => compareInfo.Compare("\u00DF", "ss", options) == 0;
     }
 }

--- a/Meziantou.Polyfill.Tests/SystemTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemTests.cs
@@ -138,6 +138,28 @@ public class SystemTests
         Assert.Equal("ab\u00ADc", "ab\u00ADc".Replace("\u00AD", "Z", comparisonType));
         Assert.Equal("\u00AD\u00AD", "\u00AD\u00AD".Replace("\u00AD", "Z", comparisonType));
     }
+
+    [Theory]
+    [InlineData(StringComparison.InvariantCulture)]
+    [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+    public void String_Replace_CultureSensitive_IgnorableTailInOldValue(StringComparison comparisonType)
+    {
+        // oldValue has no weightless tail, so the target's U+00AD is not part of the match
+        Assert.Equal("X\u00ADc", "ab\u00ADc".Replace("ab", "X", comparisonType));
+
+#if NETFRAMEWORK
+        // NLS folds the target characters that pair with oldValue's own weightless tail into the match, so
+        // the trailing U+00AD is replaced along with it. ICU does not do this, and .NET Framework is the
+        // only target framework here that always uses NLS.
+        Assert.Equal("Xc", "ab\u00ADc".Replace("ab\u00AD", "X", comparisonType));
+        Assert.Equal("X", "ab\u00AD".Replace("ab\u00AD", "X", comparisonType));
+        Assert.Equal("aXb", "a\u00DF\u00ADb".Replace("ss\u00AD", "X", comparisonType));
+        Assert.Equal("X Xc", "ab\u00AD ab\u00ADc".Replace("ab\u00AD", "X", comparisonType));
+
+        // A weightless oldValue still replaces nothing, even though its tail is weightless too
+        Assert.Equal("ab\u00ADc", "ab\u00ADc".Replace("\u00AD\u00AD", "X", comparisonType));
+#endif
+    }
 #pragma warning restore RS0030
 
     [Fact]

--- a/Meziantou.Polyfill/Meziantou.Polyfill.csproj
+++ b/Meziantou.Polyfill/Meziantou.Polyfill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>1.0.162</Version>
+    <Version>1.0.163</Version>
     <TransformOnBuild>true</TransformOnBuild>
     <RoslynVersion>4.3.1</RoslynVersion>
 


### PR DESCRIPTION
GetMatchLength returned the shortest region of the target equal to oldValue. NLS also folds the target characters that pair with oldValue's own weightless tail into the match, so that region falls one character short for each of them and the replacement leaves those characters behind. For example, "ab\u00ADc".Replace("ab\u00AD", "X", InvariantCulture) returned "X\u00ADc" instead of "Xc".

The match is now extended over as many weightless target characters as oldValue carries at its own tail. That count depends only on oldValue, so it is computed once per call rather than once per occurrence. A zero-length match is never extended: an oldValue with no collation weight has to keep stopping the replacement, and lifting its length to 1 would slip past that guard and replace a region that does not match.

ICU follows an unrelated rule, extending over completely-ignorable characters regardless of oldValue, and applying the NLS rule there makes its results worse. The extension is therefore applied only when the collation implementation is NLS, detected through the sharp-s contraction that NLS applies at the default strength and ICU does not. This is a runtime check rather than #if NETFRAMEWORK because a netstandard2.0 assembly running on .NET Framework uses NLS while its target framework says otherwise.

Ordinal comparisons are unaffected and keep the existing fast path. The new test asserts the NLS behaviour on the .NET Framework targets, where the polyfill rather than the BCL is the implementation under test.

Fixes https://github.com/meziantou/Meziantou.Polyfill/issues/305.