### PR TITLE
Add missing `String.Join()` value null checking.

### DIFF
--- a/Meziantou.Polyfill.Editor/M;System.String.Join(System.Char,System.Object[]).cs
+++ b/Meziantou.Polyfill.Editor/M;System.String.Join(System.Char,System.Object[]).cs
@@ -1,18 +1,23 @@
+using System;
+
 static partial class PolyfillExtensions
 {
     extension(string)
     {
-        public static string Join(char separator, params object?[] value)
+        public static string Join(char separator, params object?[] values)
         {
+            if (values is null)
+                throw new ArgumentNullException(nameof(values));
+
             var sb = new System.Text.StringBuilder();
-            for (int i = 0; i < value.Length; i++)
+            for (int i = 0; i < values.Length; i++)
             {
                 if (i > 0)
                 {
                     sb.Append(separator);
                 }
 
-                sb.Append(value[i]);
+                sb.Append(values[i]);
             }
 
             return sb.ToString();

--- a/Meziantou.Polyfill.Editor/M;System.String.Join(System.Char,System.String[]).cs
+++ b/Meziantou.Polyfill.Editor/M;System.String.Join(System.Char,System.String[]).cs
@@ -1,9 +1,14 @@
+using System;
+
 static partial class PolyfillExtensions
 {
     extension(string)
     {
         public static string Join(char separator, params string?[] value)
         {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
             var sb = new System.Text.StringBuilder();
             for (int i = 0; i < value.Length; i++)
             {

--- a/Meziantou.Polyfill.Editor/M;System.String.Join``1(System.Char,System.Collections.Generic.IEnumerable{``0}).cs
+++ b/Meziantou.Polyfill.Editor/M;System.String.Join``1(System.Char,System.Collections.Generic.IEnumerable{``0}).cs
@@ -1,13 +1,17 @@
+using System;
 using System.Collections.Generic;
 
 static partial class PolyfillExtensions
 {
     extension(string)
     {
-        public static string Join<T>(char separator, IEnumerable<T> value)
+        public static string Join<T>(char separator, IEnumerable<T> values)
         {
+            if (values is null)
+                throw new ArgumentNullException(nameof(values));
+
             var sb = new System.Text.StringBuilder();
-            using (var enumerator = value.GetEnumerator())
+            using (var enumerator = values.GetEnumerator())
             {
                 if (enumerator.MoveNext())
                 {

--- a/Meziantou.Polyfill.Tests/SystemTests.cs
+++ b/Meziantou.Polyfill.Tests/SystemTests.cs
@@ -490,6 +490,19 @@ public class SystemTests
     }
 
     [Fact]
+    public void String_Join_Char_NullValues()
+    {
+        var stringArray = Assert.Throws<ArgumentNullException>(() => string.Join(',', (string?[])null!));
+        Assert.Equal("value", stringArray.ParamName);
+
+        var objectArray = Assert.Throws<ArgumentNullException>(() => string.Join(',', (object?[])null!));
+        Assert.Equal("values", objectArray.ParamName);
+
+        var enumerable = Assert.Throws<ArgumentNullException>(() => string.Join(',', (IEnumerable<string>)null!));
+        Assert.Equal("values", enumerable.ParamName);
+    }
+
+    [Fact]
     public void ArgumentNullException_ThrowIfNull()
     {
         object? sample = null;


### PR DESCRIPTION
Exposed via unit testing on a net472/net8.0 dual TFM project. This is to match dotnet's implementation which does such checks.

Version number not bumped as there's other PRs in the pipeline.