### PR TITLE
Update to .NET 11 RC1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
         key: nuget-${{ hashFiles('**/Meziantou.Polyfill.Generator.csproj', '**/global.json') }}
     - run: dotnet build Meziantou.Polyfill.Generator/Meziantou.Polyfill.Generator.csproj
     - run: dotnet run --no-build --project Meziantou.Polyfill.Generator/Meziantou.Polyfill.Generator.csproj
-    - run: dotnet test --project Meziantou.Polyfill.SourceGenerator.Tests/Meziantou.Polyfill.SourceGenerator.Tests.csproj
+    - run: dotnet test --project ${{ github.workspace }}/Meziantou.Polyfill.SourceGenerator.Tests/Meziantou.Polyfill.SourceGenerator.Tests.csproj
 
   tests:
     runs-on: windows-latest
@@ -133,7 +133,7 @@ jobs:
         key: nuget-${{ hashFiles('**/Meziantou.Polyfill.Generator.csproj', '**/global.json') }}
     - run: dotnet build Meziantou.Polyfill.Generator/Meziantou.Polyfill.Generator.csproj
     - run: dotnet run --no-build --project Meziantou.Polyfill.Generator/Meziantou.Polyfill.Generator.csproj
-    - run: dotnet test --project Meziantou.Polyfill.Tests/Meziantou.Polyfill.Tests.csproj
+    - run: dotnet test --project ${{ github.workspace }}/Meziantou.Polyfill.Tests/Meziantou.Polyfill.Tests.csproj
 
   deploy:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
         key: nuget-${{ hashFiles('**/Meziantou.Polyfill.Generator.csproj', '**/global.json') }}
     - run: dotnet build Meziantou.Polyfill.Generator/Meziantou.Polyfill.Generator.csproj
     - run: dotnet run --no-build --project Meziantou.Polyfill.Generator/Meziantou.Polyfill.Generator.csproj
-    - run: dotnet test Meziantou.Polyfill.SourceGenerator.Tests
+    - run: dotnet test --project Meziantou.Polyfill.SourceGenerator.Tests/Meziantou.Polyfill.SourceGenerator.Tests.csproj
 
   tests:
     runs-on: windows-latest
@@ -133,7 +133,7 @@ jobs:
         key: nuget-${{ hashFiles('**/Meziantou.Polyfill.Generator.csproj', '**/global.json') }}
     - run: dotnet build Meziantou.Polyfill.Generator/Meziantou.Polyfill.Generator.csproj
     - run: dotnet run --no-build --project Meziantou.Polyfill.Generator/Meziantou.Polyfill.Generator.csproj
-    - run: dotnet test Meziantou.Polyfill.Tests
+    - run: dotnet test --project Meziantou.Polyfill.Tests/Meziantou.Polyfill.Tests.csproj
 
   deploy:
     runs-on: 'ubuntu-latest'

--- a/Meziantou.Polyfill.Generator/Program.cs
+++ b/Meziantou.Polyfill.Generator/Program.cs
@@ -823,7 +823,7 @@ static async Task DetectAndAssignVersionsAsync(Polyfill[] polyfills, CSharpCompi
         ("microsoft.netcore.app.ref", "8.0.0", "net8.0", Path.Combine("ref", "net8.0")),
         ("microsoft.netcore.app.ref", "9.0.0", "net9.0", Path.Combine("ref", "net9.0")),
         ("microsoft.netcore.app.ref", "10.0.0", "net10.0", Path.Combine("ref", "net10.0")),
-        ("microsoft.netcore.app.ref", "11.0.0-preview.7.26381.103", "net11.0", Path.Combine("ref", "net11.0")),
+        ("microsoft.netcore.app.ref", "11.0.0-rc.1.26425.128", "net11.0", Path.Combine("ref", "net11.0")),
     };
 
     // Build TFM definitions from known package list

--- a/Meziantou.Polyfill.SourceGenerator.Tests/SourceGeneratorTests.cs
+++ b/Meziantou.Polyfill.SourceGenerator.Tests/SourceGeneratorTests.cs
@@ -12,7 +12,7 @@ namespace Meziantou.Polyfill.SourceGenerator.Tests;
 
 public sealed class SourceGeneratorTests
 {
-    private const string LatestDotnetPackageVersion = "11.0.0-preview.7.26381.103";
+    private const string LatestDotnetPackageVersion = "11.0.0-rc.1.26425.128";
     private const string LatestDotnetTfm = "net11.0";
 
     [Fact]

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.7.26381.103"
+    "version": "11.0.100-rc.1.26425.128"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"


### PR DESCRIPTION
Moves the repo from .NET 11 preview.7 to RC1 (`11.0.100-rc.1.26425.128`, released 2026-09-08).

## What changed

Three places pinned the preview.7 version:

- **`global.json`** — SDK version `11.0.100-preview.7.26381.103` → `11.0.100-rc.1.26425.128`
- **`Meziantou.Polyfill.Generator/Program.cs`** — the `microsoft.netcore.app.ref` package the generator downloads to determine which APIs already exist in `net11.0` (and therefore don't need a polyfill)
- **`Meziantou.Polyfill.SourceGenerator.Tests/SourceGeneratorTests.cs`** — `LatestDotnetPackageVersion`, used by the generator tests to compile against the latest ref assemblies

## Note for reviewers: the generator cache

The generator caches its TFM-support data in `polyfill-supported-versions.json`, and `TryLoadFromCache` keys that cache **only on the list of TFM names** — which is identical between preview.7 and RC1. So bumping the ref-pack version on its own would have been a no-op: the generator would have reused the stale preview.7 data.

I deleted the cache file and re-ran the generator to force a genuine re-detection against the RC1 reference assemblies. The regenerated file came back **byte-identical**, which confirms no polyfill's supported-TFM set shifted between preview.7 and RC1. That's why this diff contains no generated-code or README changes.

## Verification

- `dotnet run --project Meziantou.Polyfill.Generator` — re-detected all 1046 polyfills against the RC1 ref assemblies; output unchanged
- `dotnet build` — succeeded, **0 warnings**, 0 errors
- `Meziantou.Polyfill.Tests` — net8.0 (846), net9.0 (852), net10.0 (852), net11.0 (852), all passing
- `Meziantou.Polyfill.SourceGenerator.Tests` — 87/87 passing

Tests were run on macOS. Plain solution-level `dotnet test` fails there with `NETSDK1243`, because the .NET 11 SDK removed the Mono launch target and the `net472`/`net48`/`net481` test TFMs can no longer launch on non-Windows. **This is not a regression** — I re-ran it against preview.7 and it fails identically. The CI test jobs run on `windows-latest`, so those TFMs are covered there; locally I ran the four runnable TFMs individually instead.

## Not included

No version bump in `Meziantou.Polyfill.csproj`. `AGENTS.md` ties that to adding a new polyfill, and since the generated output is unchanged the shipped package content is identical — bumping would publish a byte-identical package. Happy to add it if you'd prefer to keep the release cadence.